### PR TITLE
Implement changes from the beginning of 4.0

### DIFF
--- a/Data/Scripts/CoreParts/AryxAutocannonEchoTurret_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxAutocannonEchoTurret_Weapon.cs
@@ -80,7 +80,7 @@ namespace Scripts
                     ElevateRate = 0.05f,
                     MinAzimuth = -180,
                     MaxAzimuth = 180,
-                    MinElevation = 0,
+                    MinElevation = -15,
                     MaxElevation = 90,
                     FixedOffset = false,
                     InventorySize = 0.3f,

--- a/Data/Scripts/CoreParts/AryxCenturionIonCannon_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxCenturionIonCannon_AmmoTypes.cs
@@ -31,7 +31,7 @@ namespace Scripts
             AmmoMagazine = "Energy",
             AmmoRound = "Centurion Ion Beam",
             HybridRound = false, //AmmoMagazine based weapon with energy cost
-            EnergyCost = 0.1f, //(((EnergyCost * DefaultDamage) * ShotsPerSecond) * BarrelsPerShot) * ShotsPerBarrel
+            EnergyCost = 3f, //(((EnergyCost * DefaultDamage) * ShotsPerSecond) * BarrelsPerShot) * ShotsPerBarrel
             BaseDamage = (float)(100 * AWEGlobalDamageScalar), //6000 per pulse
             Mass = 0, // in kilograms
             Health = 0, // 0 = disabled, otherwise how much damage it can take from other trajectiles before dying.
@@ -1119,7 +1119,7 @@ namespace Scripts
             Ewar = new EwarDef
             {
                 Enable = true, // Enables EWAR effects AND DISABLES BASE DAMAGE AND AOE DAMAGE!!
-                Type = Emp, // EnergySink, Emp, Offense, Nav, Dot, AntiSmart, JumpNull, Anchor, Tractor, Pull, Push, 
+                Type = Offense, // EnergySink, Emp, Offense, Nav, Dot, AntiSmart, JumpNull, Anchor, Tractor, Pull, Push, 
                 Mode = Effect, // Effect , Field
                 Strength = 5000000f,
                 Radius = 3f, // Meters

--- a/Data/Scripts/CoreParts/AryxPlasmaTrident_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxPlasmaTrident_AmmoTypes.cs
@@ -102,7 +102,7 @@ namespace Scripts
                 {
                     Modifier = 10f, // Multiplier for damage against shields.
                     Type = Default, // Damage vs healing against shields; Default, Heal
-                    BypassModifier = 0f, // If greater than zero, the percentage of damage that will penetrate the shield.
+                    BypassModifier = -1f, // If greater than zero, the percentage of damage that will penetrate the shield.
                 },
                 DamageType = new DamageTypes // Damage type of each element of the projectile's damage; Kinetic, Energy
                 {
@@ -237,7 +237,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
-                DesiredSpeed = 800, // voxel phasing if you go above 5100
+                DesiredSpeed = 1800, // voxel phasing if you go above 5100
                 MaxTrajectory = 4000,
                 //FieldTime was here, it's dead now is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.

--- a/Data/Scripts/CoreParts/AryxPlasmaTrident_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxPlasmaTrident_Weapon.cs
@@ -46,10 +46,10 @@ namespace Scripts {
                 LockedSmartOnly = false, // Only fire at smart projectiles that are locked on to parent grid.
                 MinimumDiameter = 0, // Minimum radius of threat to engage.
                 MaximumDiameter = 0, // Maximum radius of threat to engage; 0 = unlimited.
-                MaxTargetDistance = 4000, // Maximum distance at which targets will be automatically shot at; 0 = unlimited.
+                MaxTargetDistance = 2000, // Maximum distance at which targets will be automatically shot at; 0 = unlimited.
                 MinTargetDistance = 0, // Minimum distance at which targets will be automatically shot at.
-                TopTargets = 0, // Maximum number of targets to randomize between; 0 = unlimited.
-                TopBlocks = 0, // Maximum number of blocks to randomize between; 0 = unlimited.
+                TopTargets = 4, // Maximum number of targets to randomize between; 0 = unlimited.
+                TopBlocks = 4, // Maximum number of blocks to randomize between; 0 = unlimited.
                 StopTrackingSpeed = 0, // Do not track threats traveling faster than this speed; 0 = unlimited.
             },
             HardPoint = new HardPointDef
@@ -81,8 +81,8 @@ namespace Scripts {
                 },
                 HardWare = new HardwareDef
                 {
-                    RotateRate = 0.0075f, // Max traversal speed of azimuth subpart in radians per tick (0.1 is approximately 360 degrees per second).
-                    ElevateRate = 0.006f, // Max traversal speed of elevation subpart in radians per tick.
+                    RotateRate = 0.0175f, // Max traversal speed of azimuth subpart in radians per tick (0.1 is approximately 360 degrees per second).
+                    ElevateRate = 0.016f, // Max traversal speed of elevation subpart in radians per tick.
                     MinAzimuth = -180,
                     MaxAzimuth = 180,
                     MinElevation = -5,

--- a/Data/Scripts/CoreParts/AryxRailgunApollo_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxRailgunApollo_Weapon.cs
@@ -80,12 +80,12 @@ namespace Scripts {
                 },
                 HardWare = new HardwareDef
                 {
-                    RotateRate = 0.007f, // Max traversal speed of azimuth subpart in radians per tick (0.1 is approximately 360 degrees per second).
-                    ElevateRate = 0.007f, // Max traversal speed of elevation subpart in radians per tick.
+                    RotateRate = 0.014f, // Max traversal speed of azimuth subpart in radians per tick (0.1 is approximately 360 degrees per second).
+                    ElevateRate = 0.014f, // Max traversal speed of elevation subpart in radians per tick.
                     MinAzimuth = -180,
                     MaxAzimuth = 180,
                     MinElevation = -20,
-                    MaxElevation = 60,
+                    MaxElevation = 70,
                     HomeAzimuth = 0, // Default resting rotation angle
                     HomeElevation = 0, // Default resting elevation
                     InventorySize = 1f, // Inventory capacity in kL.

--- a/Data/Scripts/CoreParts/AryxRailgunAres_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxRailgunAres_AmmoTypes.cs
@@ -103,7 +103,7 @@ namespace Scripts
                 },
                 Shields = new ShieldDef
                 {
-                    Modifier = 0.00000000001f,
+                    Modifier = 0.1f,
                     Type = Default,
                     BypassModifier = -1f,
                 },

--- a/Data/Scripts/CoreParts/AryxRailgunAthena_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxRailgunAthena_Weapon.cs
@@ -80,8 +80,8 @@ namespace Scripts {
                 },
                 HardWare = new HardwareDef
                 {
-                    RotateRate = 0.008f, // Max traversal speed of azimuth subpart in radians per tick (0.1 is approximately 360 degrees per second).
-                    ElevateRate = 0.008f, // Max traversal speed of elevation subpart in radians per tick.
+                    RotateRate = 0.018f, // Max traversal speed of azimuth subpart in radians per tick (0.1 is approximately 360 degrees per second).
+                    ElevateRate = 0.018f, // Max traversal speed of elevation subpart in radians per tick.
                     MinAzimuth = -180,
                     MaxAzimuth = 180,
                     MinElevation = -5,


### PR DESCRIPTION
# Changes:
```
ARYXRailgunTurret
        HardPoint.HardWare.RotateRate from 0.007 to 0.014
        HardPoint.HardWare.ElevateRate from 0.007 to 0.014
        HardPoint.HardWare.MaxElevation from 60 to 70

ARYXPicketRailgun
        HardPoint.HardWare.RotateRate from 0.008 to 0.018
        HardPoint.HardWare.ElevateRate from 0.008 to 0.018

ARYXPlasmaBeamCannon
        Targeting.TopTargets from 0 to 4
        Targeting.TopBlocks from 0 to 4
        Targeting.MaxTargetDistance from 4000 to 2000
        HardPoint.HardWare.RotateRate from 0.0075 to 0.0175
        HardPoint.HardWare.ElevateRate from 0.006 to 0.016

        Ammos:
                Trident Plasma Beam:
                        DamageScales.Shields.BypassModifier from 0 to -1
                        Trajectory.DesiredSpeed from 800 to 1800

ARYXGaussCannon
        Ammos:
                AryxGaussAmmoWC:
                        DamageScales.Shields.Modifier from 1E-11 to 0.1

ARYXGaussTurret
        Ammos:
                AryxGaussAmmoWC:
                        DamageScales.Shields.Modifier from 1E-11 to 0.1

ARYX_EchoAutocannon
        HardPoint.HardWare.MinElevation from 0 to -15

ARYXLargeIonCannon
        Ammos:
                Centurion Ion Beam:
                        EnergyCost from 0.1 to 3
                Centurion EMP Fragment:
                        Ewar.Type from Emp to Offense
```