### PR TITLE
Update AryxBurstPunisher_AmmoTypes.cs

### DIFF
--- a/Data/Scripts/CoreParts/AryxBurstPunisher_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxBurstPunisher_AmmoTypes.cs
@@ -92,7 +92,7 @@ namespace Scripts
                 },
                 Shields = new ShieldDef
                 {
-                    Modifier = 3f,
+                    Modifier = 18f,
                     Type = Default, // Default, Heal
                     BypassModifier = -2f,
                 },


### PR DESCRIPTION
Raised the shield damage modifier to 18 in order to restore the shield DPS to pre-update levels, since reducing the AOE radius 
massively decreased said DPS.