### PR TITLE
Balance Tweaks

### DIFF
--- a/Data/Scripts/CoreParts/AryxBattleCyclone_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxBattleCyclone_AmmoTypes.cs
@@ -85,7 +85,7 @@ namespace Scripts
                 Grids = new GridSizeDef
                 {
                     Large = -1f,
-                    Small = -1f,
+                    Small = 0.2f,
                 },
                 Armor = new ArmorDef
                 {

--- a/Data/Scripts/CoreParts/AryxBattleCyclone_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxBattleCyclone_AmmoTypes.cs
@@ -32,7 +32,7 @@ namespace Scripts
             AmmoRound = "240mm Heavy Shell",
             HybridRound = false, //AmmoMagazine based weapon with energy cost
             EnergyCost = 0.00000000000f, //(((EnergyCost * DefaultDamage) * ShotsPerSecond) * BarrelsPerShot) * ShotsPerBarrel
-            BaseDamage = (float)(1000 * AWEGlobalDamageScalar),
+            BaseDamage = (float)(900 * AWEGlobalDamageScalar),
             Mass = 120f, // in kilograms
             Health = 0, // 0 = disabled, otherwise how much damage it can take from other trajectiles before dying.
             BackKickForce = 90000,
@@ -89,14 +89,14 @@ namespace Scripts
                 },
                 Armor = new ArmorDef
                 {
-                    Armor = 1f,
+                    Armor = 0.75f,
                     Light = -1f,
                     Heavy = -1f,
-                    NonArmor = 1.5f,
+                    NonArmor = 1.2f,
                 },
                 Shields = new ShieldDef
                 {
-                    Modifier = 1.5f,
+                    Modifier = 0.5f,
                     Type = Default,
                     BypassModifier = -2f,
                 },

--- a/Data/Scripts/CoreParts/AryxBattleHurricane_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxBattleHurricane_AmmoTypes.cs
@@ -85,7 +85,7 @@ namespace Scripts
                 Grids = new GridSizeDef
                 {
                     Large = -1f,
-                    Small = -1f,
+                    Small = 0.2f,
                 },
                 Armor = new ArmorDef
                 {

--- a/Data/Scripts/CoreParts/AryxBattleHurricane_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxBattleHurricane_AmmoTypes.cs
@@ -89,14 +89,14 @@ namespace Scripts
                 },
                 Armor = new ArmorDef
                 {
-                    Armor = 1f,
+                    Armor = 0.9f,
                     Light = -1f,
                     Heavy = -1f,
-                    NonArmor = 1.5f,
+                    NonArmor = 1.3f,
                 },
                 Shields = new ShieldDef
                 {
-                    Modifier = 1.5f,
+                    Modifier = 0.85f,
                     Type = Default,
                     BypassModifier = -2f,
                 },

--- a/Data/Scripts/CoreParts/AryxBattleHurricane_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxBattleHurricane_Weapon.cs
@@ -80,8 +80,8 @@ namespace Scripts
                 },
                 HardWare = new HardwareDef
                 {
-                    RotateRate = 0.0025f,
-                    ElevateRate = 0.0025f,
+                    RotateRate = 0.0035f,
+                    ElevateRate = 0.0035f,
                     MinAzimuth = -180,
                     MaxAzimuth = 180,
                     MinElevation = -12,

--- a/Data/Scripts/CoreParts/AryxBattleTempest_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxBattleTempest_Weapon.cs
@@ -123,7 +123,7 @@ namespace Scripts
                     BarrelsPerShot = 1,
                     TrajectilesPerBarrel = 1, // Number of Trajectiles per barrel per fire event.
                     SkipBarrels = 0,
-                    ReloadTime = 800, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    ReloadTime = 700, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     DelayUntilFire = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     HeatPerShot = 0, //heat generated per shot
                     MaxHeat = 70000, //max heat before weapon enters cooldown (70% of max heat)

--- a/Data/Scripts/CoreParts/AryxBattleTempest_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxBattleTempest_Weapon.cs
@@ -118,12 +118,12 @@ namespace Scripts
                 },
                 Loading = new LoadingDef
                 {
-                    RateOfFire = 120,
+                    RateOfFire = 100,
                     BarrelSpinRate = 0, // visual only, 0 disables and uses RateOfFire
                     BarrelsPerShot = 1,
                     TrajectilesPerBarrel = 1, // Number of Trajectiles per barrel per fire event.
                     SkipBarrels = 0,
-                    ReloadTime = 900, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    ReloadTime = 700, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     DelayUntilFire = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     HeatPerShot = 0, //heat generated per shot
                     MaxHeat = 70000, //max heat before weapon enters cooldown (70% of max heat)

--- a/Data/Scripts/CoreParts/AryxBattleTempest_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxBattleTempest_Weapon.cs
@@ -123,7 +123,7 @@ namespace Scripts
                     BarrelsPerShot = 1,
                     TrajectilesPerBarrel = 1, // Number of Trajectiles per barrel per fire event.
                     SkipBarrels = 0,
-                    ReloadTime = 700, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    ReloadTime = 800, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     DelayUntilFire = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     HeatPerShot = 0, //heat generated per shot
                     MaxHeat = 70000, //max heat before weapon enters cooldown (70% of max heat)

--- a/Data/Scripts/CoreParts/AryxBattleTyphoon_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxBattleTyphoon_AmmoTypes.cs
@@ -84,7 +84,7 @@ namespace Scripts
                 Grids = new GridSizeDef
                 {
                     Large = -1f,
-                    Small = -1f,
+                    Small = 0.2f,
                 },
                 Armor = new ArmorDef
                 {

--- a/Data/Scripts/CoreParts/AryxBattleTyphoon_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxBattleTyphoon_AmmoTypes.cs
@@ -88,7 +88,7 @@ namespace Scripts
                 },
                 Armor = new ArmorDef
                 {
-                    Armor = 1f,
+                    Armor = 1.05f,
                     Light = -1f,
                     Heavy = -1f,
                     NonArmor = 1.5f,

--- a/Data/Scripts/CoreParts/AryxBattleTyphoon_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxBattleTyphoon_Weapon.cs
@@ -81,8 +81,8 @@ namespace Scripts
                 },
                 HardWare = new HardwareDef
                 {
-                    RotateRate = 0.0025f,
-                    ElevateRate = 0.0025f,
+                    RotateRate = 0.0030f,
+                    ElevateRate = 0.0030f,
                     MinAzimuth = -180,
                     MaxAzimuth = 180,
                     MinElevation = -5,

--- a/Data/Scripts/CoreParts/AryxPlasmaHelios_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxPlasmaHelios_AmmoTypes.cs
@@ -33,7 +33,7 @@ namespace Scripts
             AmmoRound = "Helios Energy Bolt",
             HybridRound = false, //AmmoMagazine based weapon with energy cost
             EnergyCost = 0.24230508f, //(((EnergyCost * DefaultDamage) * ShotsPerSecond) * BarrelsPerShot) * ShotsPerBarrel
-            BaseDamage = (float)(4000 * AWEGlobalDamageScalar),
+            BaseDamage = (float)(2000 * AWEGlobalDamageScalar),
             Mass = 0f, // in kilograms
             Health = 0, // 0 = disabled, otherwise how much damage it can take from other trajectiles before dying.
             BackKickForce = 60f,
@@ -105,7 +105,7 @@ namespace Scripts
                 },
                 Shields = new ShieldDef
                 {
-                    Modifier = 12f,
+                    Modifier = 8f,
                     Type = Default,
                     BypassModifier = -2f,
                 },
@@ -148,8 +148,8 @@ namespace Scripts
                 EndOfLife = new EndOfLifeDef
                 {
                     Enable = true,
-                    Radius = 6f, // Meters
-                    Damage = (float)(7500 * AWEGlobalDamageScalar),
+                    Radius = 4f, // Meters
+                    Damage = (float)(4000 * AWEGlobalDamageScalar),
                     Depth = 3f,
                     MaxAbsorb = 0f,
                     Falloff = Linear, //.NoFalloff applies the same damage to all blocks in radius

--- a/Data/Scripts/CoreParts/AryxPlasmaHelios_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxPlasmaHelios_AmmoTypes.cs
@@ -33,7 +33,7 @@ namespace Scripts
             AmmoRound = "Helios Energy Bolt",
             HybridRound = false, //AmmoMagazine based weapon with energy cost
             EnergyCost = 0.24230508f, //(((EnergyCost * DefaultDamage) * ShotsPerSecond) * BarrelsPerShot) * ShotsPerBarrel
-            BaseDamage = (float)(2000 * AWEGlobalDamageScalar),
+            BaseDamage = (float)(4000 * AWEGlobalDamageScalar),
             Mass = 0f, // in kilograms
             Health = 0, // 0 = disabled, otherwise how much damage it can take from other trajectiles before dying.
             BackKickForce = 60f,
@@ -105,7 +105,7 @@ namespace Scripts
                 },
                 Shields = new ShieldDef
                 {
-                    Modifier = 8f,
+                    Modifier = 12f,
                     Type = Default,
                     BypassModifier = -2f,
                 },
@@ -148,8 +148,8 @@ namespace Scripts
                 EndOfLife = new EndOfLifeDef
                 {
                     Enable = true,
-                    Radius = 4f, // Meters
-                    Damage = (float)(4000 * AWEGlobalDamageScalar),
+                    Radius = 6f, // Meters
+                    Damage = (float)(7500 * AWEGlobalDamageScalar),
                     Depth = 3f,
                     MaxAbsorb = 0f,
                     Falloff = Linear, //.NoFalloff applies the same damage to all blocks in radius
@@ -159,7 +159,7 @@ namespace Scripts
                     //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
                     //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
                     ArmOnlyOnHit = false, // Detonation only is available, After it hits something, when this is true. IE, if shot down, it won't explode.
-                    MinArmingTime = 50, // In ticks, before the Ammo is allowed to explode, detonate or similar; This affects shrapnel spawning.
+                    MinArmingTime = 90, // In ticks, before the Ammo is allowed to explode, detonate or similar; This affects shrapnel spawning.
                     NoVisuals = false,
                     NoSound = false,
                     ParticleScale = 1,
@@ -236,7 +236,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
-                DesiredSpeed = 4000,
+                DesiredSpeed = 2000,
                 MaxTrajectory = 10000,
                 //FieldTime was here, it's dead now is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.

--- a/Data/Scripts/CoreParts/AryxPlasmaHelios_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxPlasmaHelios_Weapon.cs
@@ -97,12 +97,12 @@ namespace Scripts
                     CheckForAnyWeapon = false, // if true, the check will fail if ANY gun is present, false only looks for this subtype
                 },
                 Loading = new LoadingDef {
-                    RateOfFire = 260,
+                    RateOfFire = 180,
                     BarrelSpinRate = 0, // visual only, 0 disables and uses RateOfFire
                     BarrelsPerShot = 1,
                     TrajectilesPerBarrel = 1, // Number of Trajectiles per barrel per fire event.
                     SkipBarrels = 0,
-                    ReloadTime = 300, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    ReloadTime = 600, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     DelayUntilFire = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     HeatPerShot = 0, //heat generated per shot
                     MaxHeat = 70000, //max heat before weapon enters cooldown (70% of max heat)

--- a/Data/Scripts/CoreParts/AryxRailgunAres_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxRailgunAres_AmmoTypes.cs
@@ -99,7 +99,7 @@ namespace Scripts
                     Armor = 16,
                     Light = -1,
                     Heavy = -1,
-                    NonArmor = -1,
+                    NonArmor = 8,
                 },
                 Shields = new ShieldDef
                 {

--- a/Data/Scripts/CoreParts/AryxSiegeMortar_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxSiegeMortar_AmmoTypes.cs
@@ -93,7 +93,7 @@ namespace Scripts
                 },
                 Shields = new ShieldDef
                 {
-                    Modifier = 6f,
+                    Modifier = 12f,
                     Type = Default,
                     BypassModifier = -2f,
                 },

--- a/Data/Scripts/CoreParts/AryxSiegeMortar_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxSiegeMortar_Weapon.cs
@@ -115,7 +115,7 @@ namespace Scripts
                     BarrelsPerShot = 1,
                     TrajectilesPerBarrel = 1, // Number of Trajectiles per barrel per fire event.
                     SkipBarrels = 0,
-                    ReloadTime = 1650, // 29 second reload time on the avalanche.
+                    ReloadTime = 1000, // 29 second reload time on the avalanche.
                     DelayUntilFire = 15, 
                     HeatPerShot = 0, //heat generated per shot
                     MaxHeat = 70000, //max heat before weapon enters cooldown (70% of max heat)


### PR DESCRIPTION
- Normalized shield DPS / PCU between all 3 strike cannon turrets
- Balanced strike cannon turret armor and component DPS / PCU to increase by ~10% when increasing in turret size
               - This means the hurricane should have ~10% more non-shield DPS / PCU than the cyclone, and likewise the 
                  typhoon will have ~10% more than the hurricane
- Buffed hurricane and typhoon traverse
- Buffed fixed tempest ROF by ~15% so it has a reason to be used over turrets now
- Nerfed Helios a bit so it aligns more with its role of an anti-base siege weapon
- Buffed mortar ROF as it was underperforming
- Buffed Ares / Ariadne component damage, now when it hits any internal component under armor it will destroy it or at least damage it well below functional.