### PR TITLE
added missing resistances +October SG balances

### DIFF
--- a/Data/Aryx_AWE_CubeBlocks.sbc
+++ b/Data/Aryx_AWE_CubeBlocks.sbc
@@ -360,7 +360,7 @@
       </Id>
       <DisplayName>M240 Windfall Strike Cannon</DisplayName>
       <Icon>Textures\GUI\Icons\Aryx_AWE_Windfall.dds</Icon>	  
-      <Description>Muzzle Velocity: 900m/s
+      <Description>Muzzle Velocity: 1300m/s
 	  Effective Range: 4km
 	  Turreted: No
 	  Specialty Role: Balanced Kinetic
@@ -421,7 +421,7 @@
       <Description>Muzzle Velocity: 1600m/s
 	  Effective Range: 3.5km
 	  Turreted: No
-	  Specialty Role: Balanced Kinetic
+	  Specialty Role: Precision Dogfighter Assault Kinetic
 	  Ammo: 120mm Heavy Shell
 	  </Description>
 	  <CubeSize>Small</CubeSize>
@@ -784,6 +784,64 @@
 	<Definition xsi:type="MyObjectBuilder_ConveyorSorterDefinition">
 		<Id>
 			<TypeId>ConveyorSorter</TypeId>
+			<SubtypeId>ARYXArgusLaser</SubtypeId>
+		</Id>
+		<DisplayName>Argus Orb PD Laser</DisplayName>
+		<Description>Muzzle Velocity: c
+	  	Effective Range: 660m
+	  	Turreted: Yes
+	  	Specialty Role: Point Defense pulse
+	  	Ammo: Energy
+		</Description>
+		<Icon>Textures\GUI\Icons\Aryx_AWE_Argus.dds</Icon>			
+		<CubeSize>Small</CubeSize>
+		<BlockTopology>TriangleMesh</BlockTopology>
+		<Size x="1" y="2" z="1"/>
+		<ModelOffset x="0" y="0" z="0"/>
+		<Model>Models\AWE_Argus\ARYX_SmallPDOrb.mwm</Model>
+		<Components>
+			<Component Subtype="SteelPlate" Count="10" />
+			<Component Subtype="Construction" Count="5" />
+			<Component Subtype="PowerCell" Count="1" />
+			<Component Subtype="Motor" Count="8" />
+			<Component Subtype="Superconductor" Count="10" />
+			<Component Subtype="BulletproofGlass" Count="2" />
+			<Component Subtype="Computer" Count="15" />
+			<Component Subtype="SteelPlate" Count="5" />			
+		</Components>
+		<CriticalComponent Subtype="Computer" Index="0"/>
+			<MountPoints>
+				<MountPoint Side="Front" StartX="0.00" StartY="0.00" EndX="1.00" EndY="1.00"/>
+				<MountPoint Side="Back" StartX="0.00" StartY="0.00" EndX="1.00" EndY="1.00"/>
+				<MountPoint Side="Left" StartX="0.00" StartY="0.00" EndX="1.00" EndY="1.00"/>
+				<MountPoint Side="Right" StartX="0.00" StartY="0.00" EndX="1.00" EndY="1.00"/>
+				<MountPoint Side="Bottom" StartX="0.00" StartY="0.00" EndX="1.00" EndY="1.00"/>
+			</MountPoints>
+			<BuildProgressModels>
+				<Model BuildPercentUpperBound="0.33" File="Models\AWE_Argus\ARYX_SmallPDOrb_BS1.mwm"/>
+				<Model BuildPercentUpperBound="0.67" File="Models\AWE_Argus\ARYX_SmallPDOrb_BS2.mwm"/>
+				<Model BuildPercentUpperBound="1.00" File="Models\AWE_Argus\ARYX_SmallPDOrb_BS3.mwm"/>
+			</BuildProgressModels>
+		<BlockPairName>ARYXArgusLaser</BlockPairName>
+		<MirroringY>Z</MirroringY>
+		<MirroringZ>Y</MirroringZ>
+      <BuildTimeSeconds>15</BuildTimeSeconds>
+      <EdgeType>Light</EdgeType>
+	  <OverlayTexture>Textures\GUI\Screens\turret_overlay.dds</OverlayTexture>	  	  
+      <ResourceSinkGroup>Defense</ResourceSinkGroup>
+      <DamageEffectName>Damage_WeapExpl_Damaged</DamageEffectName>
+      <DamagedSound>ParticleWeapExpl</DamagedSound>
+      <DestroyEffect>BlockDestroyedExplosion_Small</DestroyEffect>
+      <DestroySound>WepSmallWarheadExpl</DestroySound>
+      <PCU>100</PCU>     		
+      <TargetingGroups>
+		<string>Weapons</string>
+      </TargetingGroups>      
+    </Definition>
+	
+	<Definition xsi:type="MyObjectBuilder_ConveyorSorterDefinition">
+		<Id>
+			<TypeId>ConveyorSorter</TypeId>
 			<SubtypeId>ARYXSmallBombBay</SubtypeId>
 		</Id>
 		<DisplayName>B2-M Shrike Bomb Bay</DisplayName>
@@ -962,7 +1020,7 @@
       </Id>
       <DisplayName>VL6 Modulus Variable-Laser</DisplayName>
       <Icon>Textures\GUI\Icons\AWEModulusLaser.dds</Icon>	  
-      <Description>Muzzle Velocity: Lightspeed
+      <Description>Muzzle Velocity: c
 	  Effective Range: 2km, damage falling off gradually over distance
 	  Turreted: Yes
 	  Specialty Role: Lowering shields, Disarming opponents
@@ -1024,7 +1082,12 @@
       </Id>
       <DisplayName>MG50 Coaxial ATLAS Gatling gun</DisplayName>
       <Icon>Textures\GUI\Icons\Aryx_AWE_FixedAtlas.dds</Icon>
-      <Description>ATLAS Gatling guns are compact rotary cannons designed to tear apart opposing strike craft. A high rate of fire and large magazine allows this weapon to easily intercept incoming threats. [ 1.2KM RANGE - Accepts 40mm ATLAS ammo. (Kinetic)]</Description>
+      <Description>Muzzle Velocity: 1000m/s
+	  Effective Range: 1.2km
+	  Turreted: No
+	  Specialty Role: Light Fighter Kinetic Repeater
+	  Ammo: 40mm ATLAS
+	  </Description>
       <CubeSize>Small</CubeSize>
       <BlockTopology>TriangleMesh</BlockTopology>
 	  <Size x="1" y="3" z="9"/>
@@ -1079,7 +1142,12 @@
       </Id>
       <DisplayName>PL4-S Zarya Pulse Laser</DisplayName>
       <Icon>Textures\GUI\Icons\Aryx_AWE_SmallPulseLaser.dds</Icon>
-      <Description>Pulse Lasers are light, rapid-fire laser weapons designed for combat usage aboard small strike craft. Whilst less efficient against armour, they are much more effective against shields and exposed components. [1.2KM RANGE - ENERGY WEAPON]</Description>
+      <Description>Muzzle Velocity: c
+	  Effective Range: 3.5km
+	  Turreted: No
+	  Specialty Role: Lowering shields at Long range
+	  Ammo: Energy
+	  </Description>
       <CubeSize>Small</CubeSize>
       <BlockTopology>TriangleMesh</BlockTopology>
 	  <Size x="1" y="1" z="3"/>
@@ -1129,11 +1197,11 @@
 		<DisplayName>M-1000 Avalanche Siege Mortar</DisplayName>
 		<Icon>Textures\GUI\Icons\Aryx_AWE_SiegeMortar.dds</Icon>
 		<Description>Muzzle Velocity: 800m/s
-	  	Effective Range: 10km, with 5km assist
+	  	Effective Range: 10km, with 5km AI-Aim assist
 	  	Turreted: Yes, limited-angle gimbal
 	  	Specialty Role: Kinetic siege artillery
 	  	Ammo: 1000mm Mortar shells
-		</Description>	
+		</Description>
 		<CubeSize>Large</CubeSize>
 		<BlockTopology>TriangleMesh</BlockTopology>
 			<Size x="5" y="3" z="8"/>
@@ -1189,10 +1257,10 @@
       </Id>
       <DisplayName>AC54 Chord Autocannon</DisplayName>
       <Icon>Textures\GUI\Icons\Aryx_AWE_FixedChord.dds</Icon>
-      <Description>Muzzle Velocity: 1500m/s
-	  Effective Range: 4km
+      <Description>Muzzle Velocity: 2000m/s
+	  Effective Range: 5km
 	  Turreted: No
-	  Specialty Role: Balanced Kinetic repeater
+	  Specialty Role: Fighter-to-fighter Kinetic repeater
 	  Ammo: 54mm Autocannon
 	</Description>
       <CubeSize>Small</CubeSize>
@@ -1294,7 +1362,7 @@
 			<SubtypeId>ARYX_ChordAutocannon</SubtypeId>
 		</Id>
 		<DisplayName>AC54 Chord</DisplayName>
-        <Description>Muzzle Velocity: 1500m/s
+        <Description>Muzzle Velocity: 2000m/s
 	  Effective Range: 4km
 	  Turreted: Yes
 	  Specialty Role: Balanced Kinetic repeater
@@ -1372,7 +1440,7 @@
 			<SubtypeId>ARYX_ChordAutocannon_SG</SubtypeId>
 		</Id>
 		<DisplayName>AC54 Chord</DisplayName>
-        <Description>Muzzle Velocity: 1500m/s
+        <Description>Muzzle Velocity: 2000m/s
 	  Effective Range: 4km
 	  Turreted: Yes
 	  Specialty Role: Balanced Kinetic repeater
@@ -1569,8 +1637,8 @@
 			<SubtypeId>ARYXPlasmaPulser</SubtypeId>
 		</Id>	
 		<DisplayName>M5D-4E Helios Plasma Rifle</DisplayName>
-		<Description>Muzzle Velocity: 4000m/s
-	  Effective Range: 10km
+		<Description>Muzzle Velocity: 2000m/s
+	  Effective Range: 10km (Arms after 1.5s)
 	  Turreted: No
 	  Specialty Role: Plasma siege artillery
 	  Ammo: Energy
@@ -1630,7 +1698,12 @@
 		</Id>
 		<DisplayName>M100-V Prometheus Focus Beam Lance</DisplayName>
 		<Icon>Textures\GUI\Icons\Aryx_AWE_FocusBeamLance.dds</Icon>
-		<Description>A heavy drilling laser converted for battle via advanced modification (we upped the voltage). Fires a 1-second T2 equivalent pulse that builds upto a final charge, which delivers a pulse that deals 400% damage. [5KM RANGE - ENERGY WEAPON (Energy)]</Description>	
+		<Description>Muzzle Velocity: c
+		Effective Range: 7km
+		Turreted: No
+		Specialty Role: Lowering shields at Long range
+		Ammo: Energy
+		</Description>
 		<CubeSize>Large</CubeSize>
 		<BlockTopology>TriangleMesh</BlockTopology>
 		<Size x="1" y="1" z="6"/>
@@ -1690,7 +1763,7 @@
 	  Turreted: No
 	  Specialty Role: Long range sniping
 	  Ammo: 1200mm Ferrous Slug
-		</Description>	
+		</Description>
 		<CubeSize>Large</CubeSize>
 		<BlockTopology>TriangleMesh</BlockTopology>
 		<Size x="3" y="2" z="9"/>
@@ -1805,11 +1878,12 @@
 			<SubtypeId>ARYXHeavyCoilgun</SubtypeId>
 		</Id>
 		<DisplayName>E0-F Predator-850 Coilgun</DisplayName>
-		<Description>The Predator Coilgun is a massive sniper weapon that delivers a massive punch at relativistic velocity, though the rounds lose damage over range. [10KM TRAVEL, 6KM FALLOFF - Accepts 850mm Ferrous. (Kinetic)]
-		Effects: Fires a hitscan kinetic slug that explodes on impact and penetrates 8 blocks of heavy armour.
-		Size: 3x2x21
-		Role: Heavy Sniper
-		</Description>	
+		<Description>Muzzle Velocity: c
+	  	Effective Range: 10km
+	  	Turreted: No
+	  	Specialty Role: Heavy Kinetic Sniper, weak to armor
+	  	Ammo: 850mm Ferrous
+		</Description>
 		<Icon>Textures\GUI\Icons\Aryx_AWE_HeavyCoilgun.dds</Icon>
 		<CubeSize>Large</CubeSize>
 		<BlockTopology>TriangleMesh</BlockTopology>
@@ -1873,7 +1947,12 @@
       </Id>
       <DisplayName>KR115 Athena Picket Railgun Turret</DisplayName>
       <Icon>Textures\GUI\Icons\Aryx_AWE_PicketRailgun.dds</Icon>
-      <Description>The Athena is a medium-weight long range point defence weapon, utilising a revolver drum to fire three shots in rapid succession (Lawsuit from MA pending). Placing multiple in close proximity will cause interference with targeting.[5KM RANGE - Accepts 115mm Ferrous. (Kinetic)]</Description>
+      <Description>Muzzle Velocity: 5000m/s
+	  Effective Range: 10km, with 5km AI-Aiming (Falloff from 5km)
+	  Turreted: Yes, 3-round-burst
+	  Specialty Role: Long range sniping
+	  Ammo: 115mm Ferrous
+	  </Description>
       <CubeSize>Large</CubeSize>
       <BlockTopology>TriangleMesh</BlockTopology>
       <Size x="1" y="2" z="3"/>
@@ -1920,7 +1999,12 @@
 			<SubtypeId>ARYXLightRailgun</SubtypeId>
 		</Id>
 		<DisplayName>KR115 Antaeus Railgun</DisplayName>
-		<Description>The Antaeus is a lightweight railgun designed to facilitate ship-to-ship combat of fighters and bombardment of larger vessels. [10KM TRAVEL - Accepts 115mm Ferrous. (Kinetic)]</Description>	
+		<Description>Muzzle Velocity: 5000m/s
+		Effective Range: 10km (Falloff from 5km)
+		Turreted: No
+		Specialty Role: Long range sniping
+		Ammo: 115mm Ferrous
+		</Description>
 		<Icon>Textures\GUI\Icons\Aryx_AWE_LightRailgun.dds</Icon>
 		<CubeSize>Small</CubeSize>
 		<BlockTopology>TriangleMesh</BlockTopology>
@@ -2075,7 +2159,7 @@
       <DisplayName>T600A3 Magnetar Shock Cannon</DisplayName>
       <Icon>Textures\GUI\Icons\AryxMagnetarCannon.dds</Icon>
       <Description>Muzzle Velocity: 1800m/s
-	  Effective Range: 5km
+	  Effective Range: 5km (Arms after .83s)
 	  Turreted: Yes, triple-barreled
 	  Specialty Role: Lowering shields, Moderate damage to internal components
 	  Ammo: Energy
@@ -2137,7 +2221,7 @@
       </Id>
       <DisplayName>Aurora Combat Laser</DisplayName>
       <Icon>Textures\GUI\Icons\AryxLaserGatling.dds</Icon>		  
-      <Description>Muzzle Velocity: Lightspeed
+      <Description>Muzzle Velocity: c
 	  Effective Range: 2km
 	  Turreted: Yes
 	  Specialty Role: Anti-Infantry, Balanced laser repeater
@@ -2202,7 +2286,7 @@
       <DisplayName>T400A2 Quasar Shock Cannon</DisplayName>
       <Icon>Textures\GUI\Icons\AryxQuasarCannon.dds</Icon>
       <Description>Muzzle Velocity: 1800m/s
-	  Effective Range: 5km
+	  Effective Range: 5km (Arms after .83s)
 	  Turreted: Yes, double-barreled
 	  Specialty Role: Lowering shields, Moderate damage to internal components
 	  Ammo: Energy
@@ -2265,7 +2349,7 @@
       <DisplayName>T200A1 Pulsar Shock Cannon</DisplayName>
       <Icon>Textures\GUI\Icons\AryxPulsarCannon.dds</Icon>
       <Description>Muzzle Velocity: 1800m/s
-	  Effective Range: 5km
+	  Effective Range: 5km (Arms after .83s)
 	  Turreted: Yes
 	  Specialty Role: Lowering shields, Moderate damage to internal components
 	  Ammo: Energy
@@ -2385,7 +2469,7 @@
       </Id>
       <DisplayName>AL35-R Spartan Plasma Cannon</DisplayName>
       <Icon>Textures\GUI\Icons\Aryx_AWE_MiniSpartan.dds</Icon>	  
-      <Description>Muzzle Velocity: 2200m/s
+      <Description>Muzzle Velocity: 1800m/s
 	  Effective Range: 3km
 	  Turreted: No
 	  Specialty Role: Lowering heavy shields and Light armor

--- a/Data/Scripts/CoreParts/AryxAutocannonChordStatic_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxAutocannonChordStatic_Weapon.cs
@@ -106,12 +106,12 @@ namespace Scripts
                     CheckForAnyWeapon = false, // if true, the check will fail if ANY gun is present, false only looks for this subtype
                 },
                 Loading = new LoadingDef {
-                    RateOfFire = 180,
+                    RateOfFire = 280,
                     BarrelSpinRate = 0, // visual only, 0 disables and uses RateOfFire
                     BarrelsPerShot = 1,
                     TrajectilesPerBarrel = 1, // Number of Trajectiles per barrel per fire event.
                     SkipBarrels = 4,
-                    ReloadTime = 150, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    ReloadTime = 70, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     DelayUntilFire = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     HeatPerShot = 0, //heat generated per shot
                     MaxHeat = 70000, //max heat before weapon enters cooldown (70% of max heat)

--- a/Data/Scripts/CoreParts/AryxAutocannonChord_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxAutocannonChord_AmmoTypes.cs
@@ -32,7 +32,7 @@ namespace Scripts
             AmmoRound = "AryxAutocannonAmmoWC",
             HybridRound = false, //AmmoMagazine based weapon with energy cost
             EnergyCost = 0.00000000000f, //(((EnergyCost * DefaultDamage) * ShotsPerSecond) * BarrelsPerShot) * ShotsPerBarrel
-            BaseDamage = (float)(800 * AWEGlobalDamageScalar),
+            BaseDamage = (float)(650 * AWEGlobalDamageScalar),
             Mass = 1f, // in kilograms
             Health = 0, // 0 = disabled, otherwise how much damage it can take from other trajectiles before dying.
             BackKickForce = 4000,
@@ -235,7 +235,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
-                DesiredSpeed = 1500,
+                DesiredSpeed = 2000,
                 MaxTrajectory = 5000f,
                 //FieldTime was here, it's dead now is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.

--- a/Data/Scripts/CoreParts/AryxBattleCyclone_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxBattleCyclone_Weapon.cs
@@ -25,6 +25,7 @@ namespace Scripts
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
+                        DurabilityMod = 0.25f,
                     },
                     new MountPointDef {
                         SubtypeId = "ARYXCycloneCannon_SG",
@@ -32,6 +33,7 @@ namespace Scripts
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
+                        DurabilityMod = 0.25f,
                     },
                 },
                 Muzzles = new[] {

--- a/Data/Scripts/CoreParts/AryxBattleHurricane_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxBattleHurricane_Weapon.cs
@@ -25,6 +25,7 @@ namespace Scripts
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
+                        DurabilityMod = 0.25f,
                     },
                 },
                 Muzzles = new[] {

--- a/Data/Scripts/CoreParts/AryxBattleStorm_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxBattleStorm_AmmoTypes.cs
@@ -32,10 +32,10 @@ namespace Scripts
             AmmoRound = "120mm Heavy Shell [Storm]", // Name of ammo in terminal, should be different for each ammo type used by the same weapon.
             HybridRound = false, // Use both a physical ammo magazine and energy per shot.
             EnergyCost = 0f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
-            BaseDamage = (float)(1000 * AWEGlobalDamageScalar), // Direct damage; one steel plate is worth 100.
+            BaseDamage = (float)(500 * AWEGlobalDamageScalar), // Direct damage; one steel plate is worth 100.
             Mass = 60, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
-            BackKickForce = 45000, // Recoil.
+            BackKickForce = 15000, // Recoil.
             DecayPerShot = 0f, // Damage to the firing weapon itself.
             HardPointUsable = true, // Whether this is a primary ammo type fired directly by the turret. Set to false if this is a shrapnel ammoType and you don't want the turret to be able to select it directly.
             EnergyMagazineSize = 0, // For energy weapons, how many shots to fire before reloading.
@@ -88,20 +88,20 @@ namespace Scripts
                 Grids = new GridSizeDef
                 {
                     Large = -1f, // Multiplier for damage against large grids.
-                    Small = 0.75f, // Multiplier for damage against small grids.
+                    Small = 1.5f, // Multiplier for damage against small grids.
                 },
                 Armor = new ArmorDef
                 {
-                    Armor = 0.5f, // Multiplier for damage against all armor. This is multiplied with the specific armor type multiplier (light, heavy).
+                    Armor = -1f, // Multiplier for damage against all armor. This is multiplied with the specific armor type multiplier (light, heavy).
                     Light = -1f, // Multiplier for damage against light armor.
                     Heavy = -1f, // Multiplier for damage against heavy armor.
                     NonArmor = -1f, // Multiplier for damage against every else.
                 },
                 Shields = new ShieldDef
                 {
-                    Modifier = 4f, // Multiplier for damage against shields.
+                    Modifier = -1f, // Multiplier for damage against shields.
                     Type = Default, // Damage vs healing against shields; Default, Heal
-                    BypassModifier = -2f, // If greater than zero, the percentage of damage that will penetrate the shield.
+                    BypassModifier = -1f, // If greater than zero, the percentage of damage that will penetrate the shield.
                 },
                 DamageType = new DamageTypes // Damage type of each element of the projectile's damage; Kinetic, Energy
                 {
@@ -150,7 +150,7 @@ namespace Scripts
                     Enable = true,
                     Radius = 3f, // Meters
                     Damage = (float)(1500 * AWEGlobalDamageScalar),
-                    Depth = 1f,
+                    Depth = 1.5f,
                     MaxAbsorb = 0f,
                     Falloff = Linear, //.NoFalloff applies the same damage to all blocks in radius
                     //.Linear drops evenly by distance from center out to max radius
@@ -165,7 +165,7 @@ namespace Scripts
                     ParticleScale = 0.5f,
                     CustomParticle = "AWE_Cyclone_Explosion", // Particle SubtypeID, from your Particle SBC
                     CustomSound = "ArcWepSmallMissileExplShip", // SubtypeID from your Audio SBC, not a filename
-                    Shape = Round, // Round or Diamond
+                    Shape = Diamond, // Round or Diamond
                 }, 
             },
             Ewar = new EwarDef

--- a/Data/Scripts/CoreParts/AryxBattleStorm_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxBattleStorm_Weapon.cs
@@ -1,4 +1,4 @@
-﻿using static Scripts.Structure;
+using static Scripts.Structure;
 using static Scripts.Structure.WeaponDefinition;
 using static Scripts.Structure.WeaponDefinition.ModelAssignmentsDef;
 using static Scripts.Structure.WeaponDefinition.HardPointDef;
@@ -110,7 +110,7 @@ namespace Scripts {
                     BarrelsPerShot = 1, // How many muzzles will fire a projectile per fire event.
                     TrajectilesPerBarrel = 1, // Number of projectiles per muzzle per fire event.
                     SkipBarrels = 0, // Number of muzzles to skip after each fire event.
-                    ReloadTime = 150, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    ReloadTime = 120, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     MagsToLoad = 1, // Number of physical magazines to consume on reload.
                     DelayUntilFire = 0, // How long the weapon waits before shooting after being told to fire. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     HeatPerShot = 0, // Heat generated per shot.

--- a/Data/Scripts/CoreParts/AryxBattleWindfall_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxBattleWindfall_AmmoTypes.cs
@@ -234,7 +234,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
-                DesiredSpeed = 900,
+                DesiredSpeed = 1300,
                 MaxTrajectory = 4000f,
                 //FieldTime was here, it's dead now is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 1f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.

--- a/Data/Scripts/CoreParts/AryxBattleWindfall_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxBattleWindfall_Weapon.cs
@@ -25,6 +25,7 @@ namespace Scripts
                         MuzzlePartId = "None",
                         AzimuthPartId = "None",
                         ElevationPartId = "None",
+                        DurabilityMod = 0.25f,
                     },
                 },
                 Muzzles = new[] {

--- a/Data/Scripts/CoreParts/AryxChaingunProwler_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxChaingunProwler_Weapon.cs
@@ -25,6 +25,7 @@ namespace Scripts
                         MuzzlePartId = "GatlingBarrel",
                         AzimuthPartId = "None",
                         ElevationPartId = "None",
+                        DurabilityMod = 0.25f,
                     },
                     
                 },

--- a/Data/Scripts/CoreParts/AryxCoilgunHunter_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxCoilgunHunter_Weapon.cs
@@ -24,6 +24,7 @@ namespace Scripts
                         MuzzlePartId = "None",
                         AzimuthPartId = "None",
                         ElevationPartId = "None",
+                        DurabilityMod = 0.25f,
                     },
 
                 },

--- a/Data/Scripts/CoreParts/AryxCoilgunPredator_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxCoilgunPredator_Weapon.cs
@@ -24,6 +24,7 @@ namespace Scripts
                         MuzzlePartId = "None",
                         AzimuthPartId = "None",
                         ElevationPartId = "None",
+                        DurabilityMod = 0.25f,
                     },
 
                 },

--- a/Data/Scripts/CoreParts/AryxEnergyCannonMagnetar_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxEnergyCannonMagnetar_AmmoTypes.cs
@@ -32,7 +32,7 @@ namespace Scripts
             AmmoRound = "Quasar Energy Bolt", // name of ammo in terminal, should be unique for each ammo type. Used for Name field in server config
             HybridRound = false, //AmmoMagazine based weapon with energy cost
             EnergyCost = 0.149995f, //(((EnergyCost * DefaultDamage) * ShotsPerSecond) * BarrelsPerShot) * ShotsPerBarrel
-            BaseDamage = (float)(2400 * AWEGlobalDamageScalar),
+            BaseDamage = (float)(10 * AWEGlobalDamageScalar),
             Mass = 0f, // in kilograms
             Health = 0, // 0 = disabled, otherwise how much damage it can take from other trajectiles before dying.
             BackKickForce = 0f,
@@ -48,8 +48,8 @@ namespace Scripts
             },
             ObjectsHit = new ObjectsHitDef
             {
-                MaxObjectsHit = 0, // 0 = disabled
-                CountBlocks = false, // counts gridBlocks and not just entities hit
+                MaxObjectsHit = 1, // 0 = disabled
+                CountBlocks = true, // counts gridBlocks and not just entities hit
             },
             Fragment = new FragmentDef
             {
@@ -89,7 +89,7 @@ namespace Scripts
                 Grids = new GridSizeDef
                 {
                     Large = -1f,
-                    Small = -1f,
+                    Small = 0.2f,
                 },
                 Armor = new ArmorDef
                 {
@@ -100,7 +100,7 @@ namespace Scripts
                 },
                 Shields = new ShieldDef
                 {
-                    Modifier = 14f,
+                    Modifier = 12f,
                     Type = Default, // Default, Heal
                     BypassModifier = -2f,
                 },
@@ -135,11 +135,11 @@ namespace Scripts
                 ByBlockHit = new ByBlockHitDef
                 {
                     Enable = true,
-                    Radius = 3f, // Meters
-                    Damage = (float)(12000 * AWEGlobalDamageScalar),
-                    Depth = 1f, // Meters
+                    Radius = 5f, // Meters
+                    Damage = (float)(6900 * AWEGlobalDamageScalar),
+                    Depth = 3f, // Meters
                     MaxAbsorb = 0f,
-                    Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius
+                    Falloff = Linear, //.NoFalloff applies the same damage to all blocks in radius
                     //.Linear drops evenly by distance from center out to max radius
                     //.Curve drops off damage sharply as it approaches the max radius
                     //.InvCurve drops off sharply from the middle and tapers to max radius
@@ -151,8 +151,8 @@ namespace Scripts
                 {
                     Enable = true,
                     Radius = 7f, // Meters
-                    Damage = (float)(12000 * AWEGlobalDamageScalar),
-                    Depth = 2f,
+                    Damage = (float)(10000 * AWEGlobalDamageScalar),
+                    Depth = 4f,
                     MaxAbsorb = 0f,
                     Falloff = Linear, //.NoFalloff applies the same damage to all blocks in radius
                     //.Linear drops evenly by distance from center out to max radius
@@ -167,7 +167,7 @@ namespace Scripts
                     ParticleScale = 1,
                     CustomParticle = "AWE_Shockcannon_Explosion", // Particle SubtypeID, from your Particle SBC
                     CustomSound = "ArcWepShipARYX_ShockCannonHit", // SubtypeID from your Audio SBC, not a filename
-                    Shape = Diamond, // Round or Diamond
+                    Shape = Round, // Round or Diamond
                 }, 
             },
             Ewar = new EwarDef

--- a/Data/Scripts/CoreParts/AryxEnergyCannonPulsar_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxEnergyCannonPulsar_AmmoTypes.cs
@@ -32,7 +32,7 @@ namespace Scripts
             AmmoRound = "Pulsar Energy Bolt", // name of ammo in terminal, should be unique for each ammo type. Used for Name field in server config
             HybridRound = false, //AmmoMagazine based weapon with energy cost
             EnergyCost = 1, //(((EnergyCost * DefaultDamage) * ShotsPerSecond) * BarrelsPerShot) * ShotsPerBarrel
-            BaseDamage = (float)(1000 * AWEGlobalDamageScalar),
+            BaseDamage = (float)(10 * AWEGlobalDamageScalar),
             Mass = 0f, // in kilograms
             Health = 0, // 0 = disabled, otherwise how much damage it can take from other trajectiles before dying.
             BackKickForce = 0f,
@@ -48,8 +48,8 @@ namespace Scripts
             },
             ObjectsHit = new ObjectsHitDef
             {
-                MaxObjectsHit = 0, // 0 = disabled
-                CountBlocks = false, // counts gridBlocks and not just entities hit
+                MaxObjectsHit = 1, // 0 = disabled
+                CountBlocks = true, // counts gridBlocks and not just entities hit
             },
             Fragment = new FragmentDef
             {
@@ -89,18 +89,18 @@ namespace Scripts
                 Grids = new GridSizeDef
                 {
                     Large = -1f,
-                    Small = -1f,
+                    Small = 0.2f,
                 },
                 Armor = new ArmorDef
                 {
                     Armor = -1f,
                     Light = -1f,
                     Heavy = -1f,
-                    NonArmor = 2f,
+                    NonArmor = 1.6f,
                 },
                 Shields = new ShieldDef
                 {
-                    Modifier = 14f,
+                    Modifier = 12f,
                     Type = Default, // Default, Heal
                     BypassModifier = -2f,
                 },
@@ -135,11 +135,11 @@ namespace Scripts
                 ByBlockHit = new ByBlockHitDef
                 {
                     Enable = true,
-                    Radius = 2f, // Meters
-                    Damage = (float)(2000 * AWEGlobalDamageScalar),
-                    Depth = 1f, // Meters
+                    Radius = 2.5f, // Meters
+                    Damage = (float)(1700 * AWEGlobalDamageScalar),
+                    Depth = 1.5f, // Meters
                     MaxAbsorb = 0f,
-                    Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius
+                    Falloff = Linear, //.NoFalloff applies the same damage to all blocks in radius
                     //.Linear drops evenly by distance from center out to max radius
                     //.Curve drops off damage sharply as it approaches the max radius
                     //.InvCurve drops off sharply from the middle and tapers to max radius
@@ -150,8 +150,8 @@ namespace Scripts
                 EndOfLife = new EndOfLifeDef
                 {
                     Enable = true,
-                    Radius = 2.65f, // Meters
-                    Damage = (float)(4700 * AWEGlobalDamageScalar),
+                    Radius = 3f, // Meters
+                    Damage = (float)(3100 * AWEGlobalDamageScalar),
                     Depth = 1.5f,
                     MaxAbsorb = 0f,
                     Falloff = Linear, //.NoFalloff applies the same damage to all blocks in radius

--- a/Data/Scripts/CoreParts/AryxEnergyCannonQuasar_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxEnergyCannonQuasar_AmmoTypes.cs
@@ -32,7 +32,7 @@ namespace Scripts
             AmmoRound = "Quasar Energy Bolt", // name of ammo in terminal, should be unique for each ammo type. Used for Name field in server config
             HybridRound = false, //AmmoMagazine based weapon with energy cost
             EnergyCost = 0.41991602f, //(((EnergyCost * DefaultDamage) * ShotsPerSecond) * BarrelsPerShot) * ShotsPerBarrel
-            BaseDamage = (float)(2000 * AWEGlobalDamageScalar),
+            BaseDamage = (float)(10 * AWEGlobalDamageScalar),
             Mass = 0f, // in kilograms
             Health = 0, // 0 = disabled, otherwise how much damage it can take from other trajectiles before dying.
             BackKickForce = 0f,
@@ -48,8 +48,8 @@ namespace Scripts
             },
             ObjectsHit = new ObjectsHitDef
             {
-                MaxObjectsHit = 0, // 0 = disabled
-                CountBlocks = false, // counts gridBlocks and not just entities hit
+                MaxObjectsHit = 1, // 0 = disabled
+                CountBlocks = true, // counts gridBlocks and not just entities hit
             },
             Fragment = new FragmentDef
             {
@@ -89,18 +89,18 @@ namespace Scripts
                 Grids = new GridSizeDef
                 {
                     Large = -1f,
-                    Small = -1f,
+                    Small = 0.2f,
                 },
                 Armor = new ArmorDef
                 {
                     Armor = -1f,
                     Light = -1f,
                     Heavy = -1f,
-                    NonArmor = 2f,
+                    NonArmor = 1.8f,
                 },
                 Shields = new ShieldDef
                 {
-                    Modifier = 14f,
+                    Modifier = 12f,
                     Type = Default, // Default, Heal
                     BypassModifier = -2f,
                 },
@@ -135,11 +135,11 @@ namespace Scripts
                 ByBlockHit = new ByBlockHitDef
                 {
                     Enable = true,
-                    Radius = 3f, // Meters
-                    Damage = (float)(8000 * AWEGlobalDamageScalar),
-                    Depth = 1f, // Meters
+                    Radius = 3.5f, // Meters
+                    Damage = (float)(5500 * AWEGlobalDamageScalar),
+                    Depth = 2.6f, // Meters
                     MaxAbsorb = 0f,
-                    Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius
+                    Falloff = Linear, //.NoFalloff applies the same damage to all blocks in radius
                     //.Linear drops evenly by distance from center out to max radius
                     //.Curve drops off damage sharply as it approaches the max radius
                     //.InvCurve drops off sharply from the middle and tapers to max radius
@@ -150,9 +150,9 @@ namespace Scripts
                 EndOfLife = new EndOfLifeDef
                 {
                     Enable = true,
-                    Radius = 5f, // Meters
-                    Damage = (float)(11000 * AWEGlobalDamageScalar),
-                    Depth = 2f,
+                    Radius = 5.2f, // Meters
+                    Damage = (float)(8000 * AWEGlobalDamageScalar),
+                    Depth = 3.2f,
                     MaxAbsorb = 0f,
                     Falloff = Linear, //.NoFalloff applies the same damage to all blocks in radius
                     //.Linear drops evenly by distance from center out to max radius

--- a/Data/Scripts/CoreParts/AryxFlakLight_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxFlakLight_Weapon.cs
@@ -25,6 +25,7 @@ namespace Scripts
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
+                        DurabilityMod = 0.25f,
                     },
 
                 },

--- a/Data/Scripts/CoreParts/AryxGatlingGuardian_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxGatlingGuardian_Weapon.cs
@@ -116,12 +116,12 @@ namespace Scripts
                 },
                 Loading = new LoadingDef
                 {
-                    RateOfFire = 1200,
+                    RateOfFire = 2700,
                     BarrelSpinRate = 600, // visual only, 0 disables and uses RateOfFire
                     BarrelsPerShot = 1,
                     TrajectilesPerBarrel = 1, // Number of Trajectiles per barrel per fire event.
                     SkipBarrels = 0,
-                    ReloadTime = 300, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    ReloadTime = 15, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     DelayUntilFire = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     HeatPerShot = 0, //heat generated per shot
                     MaxHeat = 70000, //max heat before weapon enters cooldown (70% of max heat)

--- a/Data/Scripts/CoreParts/AryxHyperionTorpedo_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxHyperionTorpedo_Weapon.cs
@@ -23,6 +23,7 @@ namespace Scripts
                         MuzzlePartId = "None",
                         AzimuthPartId = "None",
                         ElevationPartId = "None",
+                        DurabilityMod = 0.25f,
                     },
 
                 },

--- a/Data/Scripts/CoreParts/AryxLaserArgus_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxLaserArgus_AmmoTypes.cs
@@ -32,7 +32,7 @@ namespace Scripts
             AmmoRound = "Argus Laser",
             HybridRound = false, //AmmoMagazine based weapon with energy cost
             EnergyCost = 1f, //(((EnergyCost * DefaultDamage) * ShotsPerSecond) * BarrelsPerShot) * ShotsPerBarrel
-            BaseDamage = (float)(75f * AWEGlobalDamageScalar),
+            BaseDamage = (float)(1000f * AWEGlobalDamageScalar),
             Mass = 0, // in kilograms
             Health = 0, // 0 = disabled, otherwise how much damage it can take from other trajectiles before dying.
             BackKickForce = 0f,
@@ -54,9 +54,9 @@ namespace Scripts
                 MaxIntegrity = 0f, // 0 = disabled, 1000 = any blocks with currently integrity above 1000 will be immune to damage.
                 DamageVoxels = false, // true = voxels are vulnerable to this weapon
                 SelfDamage = false, // true = allow self damage.
-                HealthHitModifier = 8f, // defaults to a value of 1, this setting modifies how much Health is subtracted from a projectile per hit (1 = per hit).
+                HealthHitModifier = 5f, // defaults to a value of 1, this setting modifies how much Health is subtracted from a projectile per hit (1 = per hit).
                 VoxelHitModifier = 1,
-                Characters = 33f,
+                Characters = 5f,
                 FallOff = new FallOffDef
                 {
                     Distance = 1000f, // Distance at which max damage begins falling off.
@@ -65,7 +65,7 @@ namespace Scripts
                 Grids = new GridSizeDef
                 {
                     Large = -1f,
-                    Small = -1f,
+                    Small = 2f,
                 },
                 Armor = new ArmorDef
                 {
@@ -76,7 +76,7 @@ namespace Scripts
                 },
                 Shields = new ShieldDef
                 {
-                    Modifier = 5, //Light laser type.
+                    Modifier = 8f, //Light laser type.
                     Type = Default,
                     BypassModifier = -2f,
                 },
@@ -104,7 +104,7 @@ namespace Scripts
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
                 DesiredSpeed = 0,
-                MaxTrajectory = 500f,
+                MaxTrajectory = 660f,
                 //FieldTime was here, it's dead now is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
                 SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed

--- a/Data/Scripts/CoreParts/AryxLaserArgus_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxLaserArgus_Weapon.cs
@@ -51,7 +51,7 @@ namespace Scripts
                 LockedSmartOnly = false, // Only fire at smart projectiles that are locked on to parent grid.
                 MinimumDiameter = 0, // 0 = unlimited, Minimum radius of threat to engage.
                 MaximumDiameter = 0, // 0 = unlimited, Maximum radius of threat to engage.
-                MaxTargetDistance = 500, // 0 = unlimited, Maximum target distance that targets will be automatically shot at.
+                MaxTargetDistance = 660, // 0 = unlimited, Maximum target distance that targets will be automatically shot at.
                 MinTargetDistance = 0, // 0 = unlimited, Min target distance that targets will be automatically shot at.
                 TopTargets = 4, // 0 = unlimited, max number of top targets to randomize between.
                 TopBlocks = 4, // 0 = unlimited, max number of blocks to randomize between
@@ -61,7 +61,7 @@ namespace Scripts
             {
                 PartName = "Argus PDL", // name of weapon in terminal
                 DeviateShotAngle = 0.00f,
-                AimingTolerance = 0.15f, // 0 - 180 firing angle
+                AimingTolerance = 0.1f, // 0 - 180 firing angle
                 AimLeadingPrediction = Off, // Off, Basic, Accurate, Advanced
                 DelayCeaseFire = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AddToleranceToTracking = false,
@@ -109,7 +109,7 @@ namespace Scripts
                     EnergyPriority = 0, // Deprecated.
                     MuzzleCheck = true, // Whether the weapon should check LOS from each individual muzzle in addition to the scope.
                     Debug = false, // Force enables debug mode.
-                    RestrictionRadius = 1.5f, // Prevents other blocks of this type from being placed within this distance of the centre of the block.
+                    RestrictionRadius = 2f, // Prevents other blocks of this type from being placed within this distance of the centre of the block.
                     CheckInflatedBox = false, // If true, the above distance check is performed from the edge of the block instead of the centre.
                     CheckForAnyWeapon = false, // If true, the check will fail if ANY weapon is present, not just weapons of the same subtype.
                 },

--- a/Data/Scripts/CoreParts/AryxLaserArgus_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxLaserArgus_Weapon.cs
@@ -25,6 +25,7 @@ namespace Scripts
                         MuzzlePartId = "OrbElevation",
                         AzimuthPartId = "OrbAzimuth",
                         ElevationPartId = "OrbElevation",
+                        DurabilityMod = 0.25f,
                     },
 
                 },

--- a/Data/Scripts/CoreParts/AryxLaserFocusBeamSmall_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxLaserFocusBeamSmall_Weapon.cs
@@ -25,6 +25,7 @@ namespace Scripts
                         MuzzlePartId = "None",
                         AzimuthPartId = "None",
                         ElevationPartId = "None",
+                        DurabilityMod = 0.25f,
                     },
                 },
                 Muzzles = new[] {

--- a/Data/Scripts/CoreParts/AryxLaserFocusBeamTurret_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxLaserFocusBeamTurret_Weapon.cs
@@ -25,6 +25,7 @@ namespace Scripts
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
+                        DurabilityMod = 0.25f,
                     },
                 },
                 Muzzles = new[] {

--- a/Data/Scripts/CoreParts/AryxLaserOculus_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxLaserOculus_Weapon.cs
@@ -25,6 +25,7 @@ namespace Scripts
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
+                        DurabilityMod = 0.25f,
                     },
 
                 },

--- a/Data/Scripts/CoreParts/AryxPhaseNovaSmall_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxPhaseNovaSmall_Weapon.cs
@@ -24,6 +24,7 @@ namespace Scripts
                         MuzzlePartId = "None",
                         AzimuthPartId = "None",
                         ElevationPartId = "None",
+                        DurabilityMod = 0.25f,
                     },
 
                 },

--- a/Data/Scripts/CoreParts/AryxPhaseNova_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxPhaseNova_Weapon.cs
@@ -24,6 +24,7 @@ namespace Scripts
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
+                        DurabilityMod = 0.25f,
                     },
 
                 },

--- a/Data/Scripts/CoreParts/AryxPlasmaHelios_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxPlasmaHelios_Weapon.cs
@@ -23,6 +23,7 @@ namespace Scripts
                         MuzzlePartId = "None",
                         AzimuthPartId = "None",
                         ElevationPartId = "None",
+                        DurabilityMod = 0.25f,
                     },
 
                 },

--- a/Data/Scripts/CoreParts/AryxRadar.cs
+++ b/Data/Scripts/CoreParts/AryxRadar.cs
@@ -23,12 +23,14 @@ namespace Scripts
                         MuzzlePartId = "None",
                         AzimuthPartId = "None",
                         ElevationPartId = "None",
+                        DurabilityMod = 0.25f,
                     },
                     new MountPointDef {
                         SubtypeId = "ARYXSmallRadar",
                         MuzzlePartId = "None",
                         AzimuthPartId = "None",
                         ElevationPartId = "None",
+                        DurabilityMod = 0.25f,
                     },
                 },
                 Muzzles = new[]{

--- a/Data/Scripts/CoreParts/AryxRailgunAres_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxRailgunAres_Weapon.cs
@@ -24,6 +24,7 @@ namespace Scripts
                         MuzzlePartId = "None",
                         AzimuthPartId = "None",
                         ElevationPartId = "None",
+                        DurabilityMod = 0.25f,
                     },
 
                 },

--- a/Data/Scripts/CoreParts/AryxRailgunAriadne_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxRailgunAriadne_Weapon.cs
@@ -24,6 +24,7 @@ namespace Scripts
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
+                        DurabilityMod = 0.25f,
                     },
 
                 },

--- a/Data/Scripts/CoreParts/AryxSiegeMortar_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxSiegeMortar_Weapon.cs
@@ -25,6 +25,7 @@ namespace Scripts
                         MuzzlePartId = "MortarElevation",
                         AzimuthPartId = "MortarAzimuth",
                         ElevationPartId = "MortarElevation",
+                        DurabilityMod = 0.25f,
                     },
                 },
                 Muzzles = new[] {

--- a/Data/Scripts/CoreParts/AryxSmallPulseLaser_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxSmallPulseLaser_AmmoTypes.cs
@@ -32,7 +32,7 @@ namespace Scripts
             AmmoRound = "Zarya Pulse Laser",
             HybridRound = false, //AmmoMagazine based weapon with energy cost
             EnergyCost = 0.5f, //(((EnergyCost * DefaultDamage) * ShotsPerSecond) * BarrelsPerShot) * ShotsPerBarrel
-            BaseDamage = (float)(450 * AWEGlobalDamageScalar),
+            BaseDamage = (float)(500 * AWEGlobalDamageScalar),
             Mass = 0f, // in kilograms
             Health = 0, // 0 = disabled, otherwise how much damage it can take from other trajectiles before dying.
             BackKickForce = 0f,
@@ -79,8 +79,8 @@ namespace Scripts
                 Characters = 8f,
                 FallOff = new FallOffDef
                 {
-                    Distance = 1200, // Distance at which max damage begins falling off.
-                    MinMultipler = 0.1f, // value from 0.0f to 1f where 0.1f would be a min damage of 10% of max damage.
+                    Distance = 1300, // Distance at which max damage begins falling off.
+                    MinMultipler = 0.3f, // value from 0.0f to 1f where 0.1f would be a min damage of 10% of max damage.
                 },
                 Grids = new GridSizeDef
                 {
@@ -96,7 +96,7 @@ namespace Scripts
                 },
                 Shields = new ShieldDef
                 {
-                    Modifier = 10f,
+                    Modifier = 12f,
                     Type = Default,
                     BypassModifier = -2f,
                 },
@@ -235,7 +235,7 @@ namespace Scripts
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
                 DesiredSpeed = 0,
-                MaxTrajectory = 3000,
+                MaxTrajectory = 3500,
                 //FieldTime was here, it's dead now is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
                 SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed

--- a/Data/Scripts/CoreParts/AryxSmallPulseLaser_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxSmallPulseLaser_Weapon.cs
@@ -25,6 +25,7 @@ namespace Scripts
                         MuzzlePartId = "None",
                         AzimuthPartId = "None",
                         ElevationPartId = "None",
+                        DurabilityMod = 0.25f,
                     },
                     
                 },


### PR DESCRIPTION
Where the DurabilityMod was missing it defaulted to 0.25 in LG and 0.05 in SG weapons per either Coresystems or aryx, I'm not sure which. This just rectifies the difference between LG and SG where they share a model, and lets you decide in the future what that factor should be.
Affected guns:
SG cyclone
SG windfall
SG radar
SG zarya
The rest of them represent no change because they already were 0.25 (LG), or not yet enabled

Additional changes added in October for small grid balance, attached
[october balance patch (SG grunkers).txt](https://github.com/Asy93/AWE-Grunker-s-Finest/files/12913029/october.balance.patch.SG.grunkers.txt)
