### PR TITLE
1st 6.0 Balance Patch

### DIFF
--- a/Data/Scripts/CoreParts/AryxBattleCyclone_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxBattleCyclone_Weapon.cs
@@ -64,7 +64,7 @@ namespace Scripts
             HardPoint = new HardPointDef
             {
                 PartName = "Cyclone Heavy Cannon", // name of weapon in terminal
-                DeviateShotAngle = 0.7f,
+                DeviateShotAngle = 0.4f,
                 AimingTolerance = 0.1f, // 0 - 180 firing angle
                 AimLeadingPrediction = Advanced, // Off, Basic, Accurate, Advanced
                 DelayCeaseFire = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).

--- a/Data/Scripts/CoreParts/AryxBattleHurricane_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxBattleHurricane_AmmoTypes.cs
@@ -89,14 +89,14 @@ namespace Scripts
                 },
                 Armor = new ArmorDef
                 {
-                    Armor = 0.7f,
+                    Armor = 1.8f,
                     Light = -1f,
                     Heavy = -1f,
-                    NonArmor = 1.3f,
+                    NonArmor = 3.5f,
                 },
                 Shields = new ShieldDef
                 {
-                    Modifier = 0.8f,
+                    Modifier = 1.6f,
                     Type = Default,
                     BypassModifier = -2f,
                 },
@@ -146,9 +146,9 @@ namespace Scripts
                 EndOfLife = new EndOfLifeDef
                 {
                     Enable = true,
-                    Radius = 9f, // Meters
+                    Radius = 5f, // Meters
                     Damage = (float)(8000 * AWEGlobalDamageScalar),
-                    Depth = 1f,
+                    Depth = 2f,
                     MaxAbsorb = 0f,
                     Falloff = Curve, //.NoFalloff applies the same damage to all blocks in radius
                     //.Linear drops evenly by distance from center out to max radius

--- a/Data/Scripts/CoreParts/AryxBattleTyphoon_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxBattleTyphoon_AmmoTypes.cs
@@ -88,14 +88,14 @@ namespace Scripts
                 },
                 Armor = new ArmorDef
                 {
-                    Armor = 0.6f,
+                    Armor = 1.35f,
                     Light = -1f,
                     Heavy = -1f,
-                    NonArmor = 1.1f,
+                    NonArmor = 3.0f,
                 },
                 Shields = new ShieldDef
                 {
-                    Modifier = 1.9f,
+                    Modifier = 4f,
                     Type = Default,
                     BypassModifier = -2f,
                 },
@@ -145,9 +145,9 @@ namespace Scripts
                 EndOfLife = new EndOfLifeDef
                 {
                     Enable = true,
-                    Radius = 9f, // Meters
+                    Radius = 4f, // Meters
                     Damage = (float)(10000 * AWEGlobalDamageScalar),
-                    Depth = 1f,
+                    Depth = 3f,
                     MaxAbsorb = 0f,
                     Falloff = Curve, //.NoFalloff applies the same damage to all blocks in radius
                     //.Linear drops evenly by distance from center out to max radius

--- a/Data/Scripts/CoreParts/AryxBattleTyphoon_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxBattleTyphoon_Weapon.cs
@@ -116,7 +116,7 @@ namespace Scripts
                     BarrelsPerShot = 1, // How many muzzles will fire a projectile per fire event.
                     TrajectilesPerBarrel = 1, // Number of projectiles per muzzle per fire event.
                     SkipBarrels = 0, // Number of muzzles to skip after each fire event.
-                    ReloadTime = 800, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    ReloadTime = 700, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     MagsToLoad = 3, // Number of physical magazines to consume on reload.
                     DelayUntilFire = 0, // How long the weapon waits before shooting after being told to fire. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     HeatPerShot = 0, // Heat generated per shot.

--- a/Data/Scripts/CoreParts/AryxEnergyCannonMagnetar_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxEnergyCannonMagnetar_AmmoTypes.cs
@@ -161,7 +161,7 @@ namespace Scripts
                     //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
                     //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
                     ArmOnlyOnHit = false, // Detonation only is available, After it hits something, when this is true. IE, if shot down, it won't explode.
-                    MinArmingTime = 30, // In ticks, before the Ammo is allowed to explode, detonate or similar; This affects shrapnel spawning.
+                    MinArmingTime = 0, // In ticks, before the Ammo is allowed to explode, detonate or similar; This affects shrapnel spawning.
                     NoVisuals = false,
                     NoSound = false,
                     ParticleScale = 1,

--- a/Data/Scripts/CoreParts/AryxEnergyCannonPulsar_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxEnergyCannonPulsar_AmmoTypes.cs
@@ -161,7 +161,7 @@ namespace Scripts
                     //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
                     //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
                     ArmOnlyOnHit = false, // Detonation only is available, After it hits something, when this is true. IE, if shot down, it won't explode.
-                    MinArmingTime = 37, // In ticks, before the Ammo is allowed to explode, detonate or similar; This affects shrapnel spawning.
+                    MinArmingTime = 0, // In ticks, before the Ammo is allowed to explode, detonate or similar; This affects shrapnel spawning.
                     NoVisuals = false,
                     NoSound = false,
                     ParticleScale = 1,

--- a/Data/Scripts/CoreParts/AryxEnergyCannonPulsar_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxEnergyCannonPulsar_Weapon.cs
@@ -56,7 +56,7 @@ namespace Scripts {
             HardPoint = new HardPointDef
             {
                 PartName = "Pulsar Shock Cannon", // name of weapon in terminal, should be unique for each weapon definition that shares a SubtypeId (i.e. multiweapons)
-                DeviateShotAngle = 0.7f,
+                DeviateShotAngle = 0.4f,
                 AimingTolerance = 0.1f, // 0 - 180 firing angle
                 AimLeadingPrediction = Accurate, // Off, Basic, Accurate, Advanced
                 DelayCeaseFire = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).

--- a/Data/Scripts/CoreParts/AryxEnergyCannonQuasar_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxEnergyCannonQuasar_AmmoTypes.cs
@@ -161,7 +161,7 @@ namespace Scripts
                     //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
                     //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
                     ArmOnlyOnHit = false, // Detonation only is available, After it hits something, when this is true. IE, if shot down, it won't explode.
-                    MinArmingTime = 38, // In ticks, before the Ammo is allowed to explode, detonate or similar; This affects shrapnel spawning.
+                    MinArmingTime = 0, // In ticks, before the Ammo is allowed to explode, detonate or similar; This affects shrapnel spawning.
                     NoVisuals = false,
                     NoSound = false,
                     ParticleScale = 1,

--- a/Data/Scripts/CoreParts/AryxFlakHeavy_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxFlakHeavy_AmmoTypes.cs
@@ -236,7 +236,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
-                DesiredSpeed = 1200,
+                DesiredSpeed = 1600,
                 MaxTrajectory = 6000f,
                 //FieldTime was here, it's dead now is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.

--- a/Data/Scripts/CoreParts/AryxFlakHeavy_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxFlakHeavy_Weapon.cs
@@ -112,12 +112,12 @@ namespace Scripts
                 },
                 Loading = new LoadingDef
                 {
-                    RateOfFire = 360,
+                    RateOfFire = 180,
                     BarrelSpinRate = 0, // visual only, 0 disables and uses RateOfFire
                     BarrelsPerShot = 1,
                     TrajectilesPerBarrel = 1, // Number of Trajectiles per barrel per fire event.
                     SkipBarrels = 0,
-                    ReloadTime = 300, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    ReloadTime = 240, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     DelayUntilFire = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     HeatPerShot = 0, //heat generated per shot
                     MaxHeat = 70000, //max heat before weapon enters cooldown (70% of max heat)

--- a/Data/Scripts/CoreParts/AryxLaserArgus_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxLaserArgus_AmmoTypes.cs
@@ -104,7 +104,7 @@ namespace Scripts
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
                 DesiredSpeed = 0,
-                MaxTrajectory = 660f,
+                MaxTrajectory = 1660f,
                 //FieldTime was here, it's dead now is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
                 SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed

--- a/Data/Scripts/CoreParts/AryxLaserArgus_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxLaserArgus_Weapon.cs
@@ -51,7 +51,7 @@ namespace Scripts
                 LockedSmartOnly = false, // Only fire at smart projectiles that are locked on to parent grid.
                 MinimumDiameter = 0, // 0 = unlimited, Minimum radius of threat to engage.
                 MaximumDiameter = 0, // 0 = unlimited, Maximum radius of threat to engage.
-                MaxTargetDistance = 660, // 0 = unlimited, Maximum target distance that targets will be automatically shot at.
+                MaxTargetDistance = 1660, // 0 = unlimited, Maximum target distance that targets will be automatically shot at.
                 MinTargetDistance = 0, // 0 = unlimited, Min target distance that targets will be automatically shot at.
                 TopTargets = 4, // 0 = unlimited, max number of top targets to randomize between.
                 TopBlocks = 4, // 0 = unlimited, max number of blocks to randomize between

--- a/Data/Scripts/CoreParts/AryxRailgunApollo_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxRailgunApollo_Weapon.cs
@@ -54,7 +54,7 @@ namespace Scripts {
             HardPoint = new HardPointDef
             {
                 PartName = "Apollo 250mm Railgun Turret", // Name of the weapon in terminal, should be unique for each weapon definition that shares a SubtypeId (i.e. multiweapons).
-                DeviateShotAngle = 0.02f, // Projectile inaccuracy in degrees.
+                DeviateShotAngle = 0.12f, // Projectile inaccuracy in degrees.
                 AimingTolerance = 20f, // How many degrees off target a turret can fire at. 0 - 180 firing angle.
                 AimLeadingPrediction = Accurate, // Level of turret aim prediction; Off, Basic, Accurate, Advanced
                 DelayCeaseFire = 120, // Measured in game ticks (6 = 100ms, 60 = 1 second, etc..). Length of time the weapon continues firing after trigger is released.

--- a/Data/Scripts/CoreParts/AryxRailgunAres_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxRailgunAres_AmmoTypes.cs
@@ -96,14 +96,14 @@ namespace Scripts
                 },
                 Armor = new ArmorDef
                 {
-                    Armor = 5,
+                    Armor = 99999999,
                     Light = -1,
                     Heavy = -1,
-                    NonArmor = 10,
+                    NonArmor = 6,
                 },
                 Shields = new ShieldDef
                 {
-                    Modifier = 16f,
+                    Modifier = 28f,
                     Type = Default,
                     BypassModifier = -2f,
                 },
@@ -234,8 +234,8 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 6000, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0,
-                DesiredSpeed = 4999f,
-                MaxTrajectory = 50000f,
+                DesiredSpeed = 10000f,
+                MaxTrajectory = 10000f,
                 //FieldTime was here, it's dead now is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
                 SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed

--- a/Data/Scripts/CoreParts/AryxRailgunAres_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxRailgunAres_Weapon.cs
@@ -55,7 +55,7 @@ namespace Scripts
             HardPoint = new HardPointDef 
             {
                 PartName = "Ares 1200mm Heavy Railgun", // name of weapon in terminal
-                DeviateShotAngle = 0,
+                DeviateShotAngle = 0.06f,
                 AimingTolerance = 0.1f, // 0 - 180 firing angle
                 AimLeadingPrediction = Accurate, // Off, Basic, Accurate, Advanced
                 DelayCeaseFire = 120, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
@@ -110,9 +110,9 @@ namespace Scripts
                     BarrelsPerShot = 1, // How many muzzles will fire a projectile per fire event.
                     TrajectilesPerBarrel = 1, // Number of projectiles per muzzle per fire event.
                     SkipBarrels = 0, // Number of muzzles to skip after each fire event.
-                    ReloadTime = 1800, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    ReloadTime = 2340, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     MagsToLoad = 10, // Number of physical magazines to consume on reload.
-                    DelayUntilFire = 30, // How long the weapon waits before shooting after being told to fire. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    DelayUntilFire = 390, // How long the weapon waits before shooting after being told to fire. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     HeatPerShot = 0, // Heat generated per shot.
                     MaxHeat = 1000, // Max heat before weapon enters cooldown (70% of max heat).
                     Cooldown = .95f, // Percentage of max heat to be under to start firing again after overheat; accepts 0 - 0.95

--- a/Data/Scripts/CoreParts/AryxRailgunAriadne_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxRailgunAriadne_Weapon.cs
@@ -55,7 +55,7 @@ namespace Scripts
             HardPoint = new HardPointDef 
             {
                 PartName = "Ariadne 1200mm Gauss Turret", // name of weapon in terminal
-                DeviateShotAngle = 0,
+                DeviateShotAngle = 0.06f,
                 AimingTolerance = 0.5f, // 0 - 180 firing angle
                 AimLeadingPrediction = Accurate, // Off, Basic, Accurate, Advanced
                 DelayCeaseFire = 600, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
@@ -110,9 +110,9 @@ namespace Scripts
                     BarrelsPerShot = 1, // How many muzzles will fire a projectile per fire event.
                     TrajectilesPerBarrel = 1, // Number of projectiles per muzzle per fire event.
                     SkipBarrels = 0, // Number of muzzles to skip after each fire event.
-                    ReloadTime = 1800, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    ReloadTime = 1440, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     MagsToLoad = 10, // Number of physical magazines to consume on reload.
-                    DelayUntilFire = 30, // How long the weapon waits before shooting after being told to fire. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    DelayUntilFire = 390, // How long the weapon waits before shooting after being told to fire. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     HeatPerShot = 0, // Heat generated per shot.
                     MaxHeat = 1000, // Max heat before weapon enters cooldown (70% of max heat).
                     Cooldown = .95f, // Percentage of max heat to be under to start firing again after overheat; accepts 0 - 0.95

--- a/Data/Scripts/CoreParts/AryxRailgunAthena_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxRailgunAthena_Weapon.cs
@@ -53,7 +53,7 @@ namespace Scripts {
             HardPoint = new HardPointDef
             {
                 PartName = "Athena 115mm Railgun Turret", // Name of the weapon in terminal, should be unique for each weapon definition that shares a SubtypeId (i.e. multiweapons).
-                DeviateShotAngle = 0.1f, // Projectile inaccuracy in degrees.
+                DeviateShotAngle = 0.25f, // Projectile inaccuracy in degrees.
                 AimingTolerance = 1f, // How many degrees off target a turret can fire at. 0 - 180 firing angle.
                 AimLeadingPrediction = Accurate, // Level of turret aim prediction; Off, Basic, Accurate, Advanced
                 DelayCeaseFire = 120, // Measured in game ticks (6 = 100ms, 60 = 1 second, etc..). Length of time the weapon continues firing after trigger is released.

--- a/Data/Scripts/CoreParts/AryxRailgunLight_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxRailgunLight_AmmoTypes.cs
@@ -93,10 +93,10 @@ namespace Scripts
                 },
                 Armor = new ArmorDef
                 {
-                    Armor = 1.1f, // Multiplier for damage against all armor. This is multiplied with the specific armor type multiplier (light, heavy).
-                    Light = -1f, // Multiplier for damage against light armor.
+                    Armor = 0.5f, // Multiplier for damage against all armor. This is multiplied with the specific armor type multiplier (light, heavy).
+                    Light = 3f, // Multiplier for damage against light armor.
                     Heavy = -1f, // Multiplier for damage against heavy armor.
-                    NonArmor = -1f, // Multiplier for damage against every else.
+                    NonArmor = 0.5f, // Multiplier for damage against every else.
                 },
                 Shields = new ShieldDef
                 {

--- a/Data/Scripts/CoreParts/AryxRailgunMedium_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxRailgunMedium_AmmoTypes.cs
@@ -94,7 +94,7 @@ namespace Scripts
                     Armor = 3.0f, // Multiplier for damage against all armor. This is multiplied with the specific armor type multiplier (light, heavy).
                     Light = -1f, // Multiplier for damage against light armor.
                     Heavy = -1f, // Multiplier for damage against heavy armor.
-                    NonArmor = 5f, // Multiplier for damage against every else.
+                    NonArmor = 2.5f, // Multiplier for damage against every else.
                 },
                 Shields = new ShieldDef
                 {
@@ -235,7 +235,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 6000, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
-                DesiredSpeed = 4999,
+                DesiredSpeed = 7500,
                 MaxTrajectory = 10000,
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
                 SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed

--- a/Data/Scripts/CoreParts/AryxSiegeMortar_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxSiegeMortar_AmmoTypes.cs
@@ -37,9 +37,9 @@ namespace Scripts
             HybridRound = false, //AmmoMagazine based weapon with energy cost
             EnergyCost = 0f, //(((EnergyCost * DefaultDamage) * ShotsPerSecond) * BarrelsPerShot) * ShotsPerBarrel
             BaseDamage = (float)(3500 * AWEGlobalDamageScalar),
-            Mass = 400000, // in kilograms
+            Mass = 200000, // in kilograms
             Health = 0, // 0 = disabled, otherwise how much damage it can take from other trajectiles before dying.
-            BackKickForce = 2250000,
+            BackKickForce = 22500000,
             DecayPerShot = 0,
             HardPointUsable = true, // set to false if this is a shrapnel ammoType and you don't want the turret to be able to select it directly.
             IgnoreWater = false,
@@ -154,7 +154,7 @@ namespace Scripts
                     //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
                     //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
                     ArmOnlyOnHit = false, // Detonation only is available, After it hits something, when this is true. IE, if shot down, it won't explode.
-                    MinArmingTime = 180, // In ticks, before the Ammo is allowed to explode, detonate or similar; This affects shrapnel spawning.
+                    MinArmingTime = 360, // In ticks, before the Ammo is allowed to explode, detonate or similar; This affects shrapnel spawning.
                     NoVisuals = false,
                     NoSound = false,
                     ParticleScale = 1,
@@ -231,7 +231,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 36000, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
-                DesiredSpeed = 800,
+                DesiredSpeed = 400,
                 MaxTrajectory = 10000,
                 GravityMultiplier = 2.25f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
                 SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed


### PR DESCRIPTION
- 240 and T200 deviation to 0.4
- no minarming time for shock cannons
- mortar speed and knockback halved, recoil increased a lot
- thrasher reload and ROF both decreased for roughly the same dps but less bursty, speed to 1600 m/s
- 480 and 600 damage pattern changed to be somewhat more penetrative
- 600 armor dps increased 
- ares & ariadne given infinite armor pen, nerfed comp damage, re-added wind up, given 0.06 deviation and 10000 m/s. Nerfed ares reload
- apollo comp damage nerfed, given 0.12 deviation and 7500 m/s
- athena comp and heavy armor damage nerfed, given 0.25 deviation and light armor damage buff
- argus range to 1600
- changed a few ATLAS settings to match stock Aryx, to try and help the projectile targeting bug