### PR TITLE
2nd 6.0 Balance Patch

### DIFF
--- a/Data/Aryx_AWE_CubeBlocks.sbc
+++ b/Data/Aryx_AWE_CubeBlocks.sbc
@@ -130,9 +130,9 @@
      Maximum Range: 10km
      Specialty Role: Medium Range, Anti-Armor, Anti-Component
      Ammo: 480mm Heavy Shell
-     Heavy Armor DPS per PCU: 16.2
-     Shield Armor DPS per PCU: 7.3
-     Component Armor DPS per PCU: 30.0
+     Heavy Armor DPS per PCU: 15.7
+     Shield Armor DPS per PCU: 8.1
+     Component Armor DPS per PCU: 30.5
      </Description>
       <CubeSize>Large</CubeSize>
       <BlockTopology>TriangleMesh</BlockTopology>
@@ -193,9 +193,9 @@
      Effective Range: 10km
      Specialty Role: Long Range, Anti-Armor, Anti-Component
      Ammo: 600mm Heavy Shell
-     Heavy Armor DPS per PCU: 12.5
-     Shield Armor DPS per PCU: 12.4
-     Component Armor DPS per PCU: 27.0
+     Heavy Armor DPS per PCU: 14.5
+     Shield Armor DPS per PCU: 13.6
+     Component Armor DPS per PCU: 32.2
      </Description>
       <CubeSize>Large</CubeSize>
       <BlockTopology>TriangleMesh</BlockTopology>
@@ -257,9 +257,9 @@
      Effective Range: 10km
      Specialty Role: Fixed, Long Range, Anti-Armor, Anti-Component
      Ammo: 600mm Heavy Shell
-     Heavy Armor DPS per PCU: 14.1
-     Shield Armor DPS per PCU: 14.0
-     Component Armor DPS per PCU: 30.4
+     Heavy Armor DPS per PCU: 14.3
+     Shield Armor DPS per PCU: 13.5
+     Component Armor DPS per PCU: 31.8
      </Description>
       <CubeSize>Large</CubeSize>
       <BlockTopology>TriangleMesh</BlockTopology>
@@ -320,9 +320,9 @@
      Effective Range: 10km
      Specialty Role: Fixed, Long Range, Anti-Armor, Anti-Component
      Ammo: 600mm Heavy Shell
-     Heavy Armor DPS per PCU: 14.1
-     Shield Armor DPS per PCU: 14.0
-     Component Armor DPS per PCU: 30.4
+     Heavy Armor DPS per PCU: 14.3
+     Shield Armor DPS per PCU: 13.5
+     Component Armor DPS per PCU: 31.8
      </Description>
       <CubeSize>Small</CubeSize>
       <BlockTopology>TriangleMesh</BlockTopology>
@@ -501,12 +501,16 @@
       <Icon>Textures\GUI\Icons\AryxJudgeCannon.dds</Icon>     
       <Description>
      Muzzle Velocity: 2400m/s
-     Effective Range: 10km
+     Effective Range: 6km
      Specialty Role: Medium Range, Kinetic, Anti Shield
      Ammo: 70mm HE Cartridge
      Heavy Armor DPS per PCU: 6.4
      Shield Armor DPS per PCU: 42.6
      Component Armor DPS per PCU: 4.3
+     Switch to Bunker Buster ammo for these different stats:
+     Heavy Armor and Component DPS per PCU: 0
+     Shield Armor DPS per PCU: 104.8
+     Muzzle Velocity: 800m/s (1.2km Minimum Arming Time)
      </Description>
       <CubeSize>Large</CubeSize>
       <BlockTopology>TriangleMesh</BlockTopology>
@@ -566,7 +570,7 @@
       <Icon>Textures\GUI\Icons\AryxJudgeCannon.dds</Icon>  
       <Description>
      Muzzle Velocity: 2400m/s
-     Effective Range: 10km
+     Effective Range: 6km
      Specialty Role: Medium Range, Kinetic, Anti Shield
      Ammo: 70mm HE Cartridge
      Heavy Armor DPS per PCU: 6.4
@@ -631,7 +635,7 @@
       <Icon>Textures\GUI\Icons\Aryx_AWE_SlantedBurstCannon.dds</Icon>     
       <Description>
      Muzzle Velocity: 2400m/s
-     Effective Range: 10km
+     Effective Range: 6km
      Specialty Role: Medium Range, Kinetic, Anti Shield
      Ammo: 70mm HE Cartridge
      Heavy Armor DPS per PCU: 6.4
@@ -698,9 +702,9 @@
      Effective Range: 6km
      Specialty Role: Medium Range, Kinetic, Anti Shield, Anti Armor, Anti Small Grid
      Ammo: 135mm Thrasher Flak Shells
-     Heavy Armor DPS per PCU: 16.3
-     Shield Armor DPS per PCU: 27.2
-     Component Armor DPS per PCU: 2.5
+     Heavy Armor DPS per PCU: 16.7
+     Shield Armor DPS per PCU: 27.8
+     Component Armor DPS per PCU: 2.6
      2x Damage Multiplier Against Small Grids
      </Description>
       <CubeSize>Large</CubeSize>
@@ -747,6 +751,69 @@
     </Definition>   
 
    <!-- <Definition xsi:type="MyObjectBuilder_ConveyorSorterDefinition">
+      <Id>
+        <TypeId>ConveyorSorter</TypeId>
+        <SubtypeId>ARYXRocketArtillery</SubtypeId>
+      </Id>
+      <DisplayName>RA-5 Starfall Rocket Artillery</DisplayName>
+      <Icon>Textures\GUI\Icons\Aryx_AWE_Starfall.dds</Icon>     
+      <Description>The Starfall is a heavy rocket battery designed for plunging fire that launches long-range nuclear missiles at extreme velocity, able to strike targets regardless of cover. The missiles disengage guidance during their final stage and accelerate to massive speeds, able to slip through PD screens and obliterate the delicate hull beneath. Hurricane on the roof; Armageddon on your doorstep. [15km range - Accepts Starfall Nuclear Missiles]
+     Effects: Fires five extremely fast and deadly missiles at enemies from long range.
+     Size: 9x10x9
+     Role: Capital Defence
+     Hardpoint: Full-traverse Turret
+     Type: Artillery Turret
+     </Description>
+         <CubeSize>Large</CubeSize>
+         <BlockTopology>TriangleMesh</BlockTopology>
+         <Size x="9" y="10" z="9"/>
+         <ModelOffset x="0" y="0" z="0"/>
+         <Model>Models\AWE_Starfall\ARYXRocketArtillery_Base.mwm</Model>
+      <Components>
+         <Component Subtype="SteelPlate" Count="7500" />
+         <Component Subtype="Construction" Count="4000" />
+         <Component Subtype="MetalGrid" Count="2000" />
+         <Component Subtype="LargeTube" Count="1000" />   
+         <Component Subtype="Motor" Count="800" />
+         <Component Subtype="Detector" Count="500" />
+         <Component Subtype="SuperchargerAWE" Count="100" />         
+         <Component Subtype="Computer" Count="1500" />
+         <Component Subtype="Construction" Count="3500" />
+         <Component Subtype="MetalGrid" Count="2000" />
+         <Component Subtype="MilitaryPlateAWE" Count="2500" />
+      </Components>
+      <CriticalComponent Index="0" Subtype="Computer"/>
+         <MountPoints>
+            <MountPoint Side="Front" StartX="0.00" StartY="0.00" EndX="9.00" EndY="3.00"/>
+            <MountPoint Side="Back" StartX="0.00" StartY="0.00" EndX="9.00" EndY="3.00"/>
+            <MountPoint Side="Left" StartX="0.00" StartY="0.00" EndX="9.00" EndY="3.00"/>
+            <MountPoint Side="Right" StartX="0.00" StartY="0.00" EndX="9.00" EndY="3.00"/>
+            <MountPoint Side="Bottom" StartX="0.00" StartY="0.00" EndX="9.00" EndY="9.00"/>
+         </MountPoints>
+         <BuildProgressModels>
+            <Model BuildPercentUpperBound="0.33" File="Models\AWE_Starfall\ARYXRocketArtillery_Base_BS1.mwm"/>
+            <Model BuildPercentUpperBound="0.67" File="Models\AWE_Starfall\ARYXRocketArtillery_Base_BS2.mwm"/>
+            <Model BuildPercentUpperBound="1.00" File="Models\AWE_Starfall\ARYXRocketArtillery_Base_BS3.mwm"/>
+         </BuildProgressModels>
+      <BlockPairName>ARYX_StarfallHIMARS</BlockPairName>
+      <MirroringY>Z</MirroringY>
+      <MirroringZ>Y</MirroringZ>
+      <BuildTimeSeconds>85</BuildTimeSeconds>
+     <GeneralDamageMultiplier>0.5</GeneralDamageMultiplier>
+      <EdgeType>Light</EdgeType>
+      < WeaponDefinitionId Subtype="AryxBurstCannonWepDef" \>
+     <OverlayTexture>Textures\GUI\Screens    urret_overlay.dds</OverlayTexture>          
+      <ResourceSinkGroup>Defense</ResourceSinkGroup>
+      <InventoryMaxVolume>0.48</InventoryMaxVolume>
+      <DamageEffectName>Damage_WeapExpl_Damaged</DamageEffectName>
+      <DamagedSound>ParticleWeapExpl</DamagedSound>
+      <DestroyEffect>BlockDestroyedExplosion_Small</DestroyEffect>
+      <DestroySound>WepSmallWarheadExpl</DestroySound>
+      <PCU>300</PCU>      
+      <TargetingGroups>
+      <string>Weapons</string>
+      </TargetingGroups>      
+    </Definition> --><!-- <Definition xsi:type="MyObjectBuilder_ConveyorSorterDefinition">
       <Id>
         <TypeId>ConveyorSorter</TypeId>
         <SubtypeId>ARYXRocketArtillery</SubtypeId>
@@ -886,6 +953,10 @@
      Heavy Armor DPS per PCU: 1.4
      Shield Armor DPS per PCU: 17.7 (against shunt-reinforced shields which block phasing)
      Component Armor DPS per PCU: 18.1
+     Switch to Bunker Buster ammo for these different stats:
+     Heavy Armor and Component DPS per PCU: 0
+     Shield Armor DPS per PCU: 133.0
+     Muzzle Velocity: 800m/s (1.2km Minimum Arming Time)
      </Description>
        <CubeSize>Large</CubeSize>
       <BlockTopology>TriangleMesh</BlockTopology>
@@ -947,7 +1018,7 @@
       <DisplayName>Argus Orb PD Laser</DisplayName>
       <Description>
      Muzzle Velocity: Hitscan
-     Effective Range: 660m
+     Effective Range: 1660m
      Specialty Role: Point Defense pulse
      Ammo: Energy
       </Description>
@@ -1183,9 +1254,9 @@
      Effective Range: 10km
      Specialty Role: Long Range, Kinetic, Anti Shield, Anti Component
      Ammo: 100mm Warrior
-     Heavy Armor DPS per PCU: 4.3
-     Shield Armor DPS per PCU: 21.3
-     Component Armor DPS per PCU: 17.0
+     Heavy Armor DPS per PCU: 4.1
+     Shield Armor DPS per PCU: 20.7
+     Component Armor DPS per PCU: 16.5
       </Description>   
       <CubeSize>Large</CubeSize>
       <BlockTopology>TriangleMesh</BlockTopology>
@@ -1244,6 +1315,12 @@
      Heavy Armor DPS per PCU: 3.4
      Shield Armor DPS per PCU: 49.1
      Component Armor DPS per PCU: 4.1
+     While not overheating, the true DPS values 
+     are ~199% higher than listed above.
+     Switch to Bunker Buster ammo for these different stats:
+     Heavy Armor and Component DPS per PCU: 0
+     Shield Armor DPS per PCU: 120.0
+     Muzzle Velocity: 400m/s (800m Minimum Arming Time)
      </Description>
       <CubeSize>Large</CubeSize>
       <BlockTopology>TriangleMesh</BlockTopology>
@@ -1418,13 +1495,13 @@
       <DisplayName>M-1000 Avalanche Siege Mortar</DisplayName>
       <Icon>Textures\GUI\Icons\Aryx_AWE_SiegeMortar.dds</Icon>
       <Description>
-     Muzzle Velocity: 800m/s
+     Muzzle Velocity: 400m/s
      Effective Range: 10km (2.4km minimum arming time)
      Specialty Role: Long Range, High Knockback, Kinetic, Siege artillery
      Ammo: 1000mm Mortar shells
-     Heavy Armor DPS per PCU: 107.5
-     Shield Armor DPS per PCU: 59.0
-     Component Armor DPS per PCU: 58.5
+     Heavy Armor DPS per PCU: 153.6
+     Shield Armor DPS per PCU: 84.3
+     Component Armor DPS per PCU: 83.6
       </Description>
       <CubeSize>Large</CubeSize>
       <BlockTopology>TriangleMesh</BlockTopology>
@@ -1549,6 +1626,8 @@
      Heavy Armor DPS per PCU: 2.2
      Shield Armor DPS per PCU: 24.0
      Component Armor DPS per PCU: 8.0
+     While not overheating, the true DPS values 
+     are ~91% higher than listed above.
    </Description>
       <CubeSize>Large</CubeSize>
       <BlockTopology>TriangleMesh</BlockTopology>
@@ -1770,6 +1849,10 @@
      Heavy Armor DPS per PCU: 3.2
      Shield Armor DPS per PCU: 19.3
      Component Armor DPS per PCU: 12.3
+     Switch to Bunker Buster ammo for these different stats:
+     Heavy Armor and Component DPS per PCU: 0
+     Shield Armor DPS per PCU: 105.4
+     Muzzle Velocity: 1000m/s (1.5km Minimum Arming Time)
    </Description>
       <Icon>Textures\GUI\Icons\AryxEchoCannon.dds</Icon>
       <CubeSize>Large</CubeSize>
@@ -1892,12 +1975,12 @@
       </Id>   
       <DisplayName>M5D-4E Helios Plasma Rifle</DisplayName>
       <Description>
-     Muzzle Velocity: 2000m/s
+     Muzzle Velocity: 1000m/s
      Effective Range: 10km (3km Minimum Arming Time)
      Specialty Role: Long range, Energy, Siege Artillery
-     Heavy Armor DPS per PCU: 12.6
-     Shield Armor DPS per PCU: 166.0
-     Component Armor DPS per PCU: 18.0
+     Heavy Armor DPS per PCU: 19.0
+     Shield Armor DPS per PCU: 249.5
+     Component Armor DPS per PCU: 27.1
       </Description>
       <Icon>Textures\GUI\Icons\AryxPlasmaGun.dds</Icon>
       <CubeSize>Large</CubeSize>
@@ -1961,6 +2044,8 @@
      Heavy Armor DPS per PCU: 3.4
      Shield Armor DPS per PCU: 44.9
      Component Armor DPS per PCU: 11.9
+     While not overheating, the true DPS values 
+     are ~12% higher than listed above.
       </Description>
       <CubeSize>Large</CubeSize>
       <BlockTopology>TriangleMesh</BlockTopology>
@@ -2017,12 +2102,12 @@
       <DisplayName>ZS-1200-S Ares Heavy Railgun</DisplayName>
       <Icon>Textures\GUI\Icons\AryxGaussCannon.dds</Icon>
       <Description>
-     Muzzle Velocity: 4999m/s
+     Muzzle Velocity: 10000m/s
      Effective Range: 10km
      Specialty Role: Long range, Kinetic, Armor Piercing
-     Heavy Armor DPS per PCU: 8.5
-     Shield Armor DPS per PCU: 11.4
-     Component Armor DPS per PCU: 14.0
+     Heavy Armor DPS per PCU: Infinite
+     Shield Armor DPS per PCU: 11.2
+     Component Armor DPS per PCU: 5.4
      Ammo: 1200mm Ferrous
       </Description>
       <CubeSize>Large</CubeSize>
@@ -2081,12 +2166,12 @@
       <DisplayName>ZS-1200 Ariana Grande Heavy Railgun Turret</DisplayName>
       <Icon>Textures\GUI\Icons\Aryx_AWE_GaussTurret.dds</Icon>
       <Description>
-     Muzzle Velocity: 4999m/s
+     Muzzle Velocity: 10000m/s
      Effective Range: 10km
      Specialty Role: Long range, Kinetic, Armor Piercing
-     Heavy Armor DPS per PCU: 8.5
-     Shield Armor DPS per PCU: 11.4
-     Component Armor DPS per PCU: 14.0
+     Heavy Armor DPS per PCU: Infinite
+     Shield Armor DPS per PCU: 16.5
+     Component Armor DPS per PCU: 8.0
      Ammo: 1200mm Ferrous
    </Description>
       <CubeSize>Large</CubeSize>
@@ -2215,12 +2300,12 @@
       <DisplayName>KR250 Apollo Railgun Turret</DisplayName>
       <Icon>Textures\GUI\Icons\AWERailgunTurret.dds</Icon>
       <Description>
-     Muzzle Velocity: 4999m/s
+     Muzzle Velocity: 7500m/s
      Effective Range: 10km
      Specialty Role: Long range, Kinetic, Armor Piercing
      Heavy Armor DPS per PCU: 9.3
      Shield Armor DPS per PCU: 8.6
-     Component Armor DPS per PCU: 10.6
+     Component Armor DPS per PCU: 4.7
      Ammo: 250mm Ferrous
    </Description>
       <CubeSize>Large</CubeSize>
@@ -2281,9 +2366,9 @@
      Muzzle Velocity: 4999m/s
      Effective Range: 10km
      Specialty Role: Long range, Kinetic, Armor Piercing
-     Heavy Armor DPS per PCU: 10.0
-     Shield Armor DPS per PCU: 6.0
-     Component Armor DPS per PCU: 6.0
+     Heavy Armor DPS per PCU: 3.7
+     Shield Armor DPS per PCU: 5.1
+     Component Armor DPS per PCU: 3.0
      Ammo: 115mm Ferrous
      </Description>
       <CubeSize>Large</CubeSize>
@@ -2336,9 +2421,9 @@
      Muzzle Velocity: 4999m/s
      Effective Range: 10km
      Specialty Role: Long range, Kinetic, Armor Piercing
-     Heavy Armor DPS per PCU: 6.7
-     Shield Armor DPS per PCU: 4.0
-     Component Armor DPS per PCU: 4.0
+     Heavy Armor DPS per PCU: 1.8
+     Shield Armor DPS per PCU: 2.5
+     Component Armor DPS per PCU: 1.5
      Ammo: 115mm Ferrous
       </Description>
       <Icon>Textures\GUI\Icons\Aryx_AWE_LightRailgun.dds</Icon>
@@ -2406,6 +2491,12 @@
      Shield Armor DPS per PCU: 25.1
      Component Armor DPS per PCU: 55.1
      Ammo: High Density Energy Cells
+     While not overheating, the true DPS values 
+     are ~60% higher than listed above.
+     Switch to Bunker Buster ammo for these different stats:
+     Heavy Armor and Component DPS per PCU: 0
+     Shield Armor DPS per PCU: 133.0
+     Muzzle Velocity: 500m/s (500m Minimum Arming Time)
       </Description>
          <CubeSize>Large</CubeSize>
          <BlockTopology>TriangleMesh</BlockTopology>
@@ -2461,7 +2552,7 @@
       <DisplayName>L82 Mace Combat Shotgun</DisplayName>
       <Description>
      Muzzle Velocity: 1500m/s
-     Effective Range: 1km (Falloff starts at 100m)
+     Effective Range: 1km (Falloff starts at 300m)
      Specialty Role: Short range, Kinetic, Anti-Shield
      Heavy Armor DPS per PCU: 17.0
      Shield Armor DPS per PCU: 138.7
@@ -2684,11 +2775,15 @@
       <Icon>Textures\GUI\Icons\AryxMagnetarCannon.dds</Icon>
       <Description>
      Muzzle Velocity: 4000m/s
-     Effective Range: 10km (2km Minimum Arming Time)
+     Effective Range: 10km
      Specialty Role: Long range, Energy, Anti Shield, Anti Component
      Heavy Armor DPS per PCU: 5.5
      Shield Armor DPS per PCU: 40.5
      Component Armor DPS per PCU: 17.5
+     Switch to Bunker Buster ammo for these different stats:
+     Heavy Armor and Component DPS per PCU: 0
+     Shield Armor DPS per PCU: 84.8
+     Muzzle Velocity: 1000m/s (2.0km Minimum Arming Time)
    </Description>
       <CubeSize>Large</CubeSize>
       <BlockTopology>TriangleMesh</BlockTopology>
@@ -2815,11 +2910,15 @@
       <Icon>Textures\GUI\Icons\AryxQuasarCannon.dds</Icon>
       <Description>
      Muzzle Velocity: 2400m/s
-     Effective Range: 10km (1.5km Minimum Arming Time)
+     Effective Range: 10km
      Specialty Role: Medium range, Energy, Anti Shield, Anti Component
      Heavy Armor DPS per PCU: 3.0
      Shield Armor DPS per PCU: 49.2
      Component Armor DPS per PCU: 21.6
+     Switch to Bunker Buster ammo for these different stats:
+     Heavy Armor and Component DPS per PCU: 0
+     Shield Armor DPS per PCU: 111.9
+     Muzzle Velocity: 800m/s (1.6km Minimum Arming Time)
    </Description>
       <CubeSize>Large</CubeSize>
       <BlockTopology>TriangleMesh</BlockTopology>
@@ -2880,11 +2979,15 @@
       <Icon>Textures\GUI\Icons\AryxPulsarCannon.dds</Icon>
       <Description>
      Muzzle Velocity: 1600m/s
-     Effective Range: 10km (1km Minimum Arming Time)
+     Effective Range: 10km
      Specialty Role: Short/Medium range, Energy, Anti Shield, Anti Component
      Heavy Armor DPS per PCU: 2.3
      Shield Armor DPS per PCU: 64.0
      Component Armor DPS per PCU: 28.1
+     Switch to Bunker Buster ammo for these different stats:
+     Heavy Armor and Component DPS per PCU: 0
+     Shield Armor DPS per PCU: 146.3
+     Muzzle Velocity: 600m/s (1.2km Minimum Arming Time)
    </Description>
       <CubeSize>Large</CubeSize>
       <BlockTopology>TriangleMesh</BlockTopology>
@@ -2946,6 +3049,13 @@
      Heavy Armor DPS per PCU: 2.5
      Shield Armor DPS per PCU: 30.0
      Component Armor DPS per PCU: 3.8
+     While not overheating, the true DPS values 
+     are ~25% higher than listed above.
+     Switch to Bunker Buster ammo for these different stats:
+     Heavy Armor and Component DPS per PCU: 0
+     Shield Armor DPS per PCU: 99.0
+     Muzzle Velocity: 1000m/s (1.5km Minimum Arming Time)
+
    </Description>
       <CubeSize>Large</CubeSize>
       <BlockTopology>TriangleMesh</BlockTopology>
@@ -3069,6 +3179,10 @@
      Heavy Armor DPS per PCU: 3.8
      Shield Armor DPS per PCU: 19.2
      Component Armor DPS per PCU: 38.4
+     Switch to Bunker Buster ammo for these different stats:
+     Heavy Armor and Component DPS per PCU: 0
+     Shield Armor DPS per PCU: 129.7
+     Muzzle Velocity: 400m/s (600m Minimum Arming Time)
      Ammo: 40mm ATLAS
       </Description>
       <CubeSize>Large</CubeSize>

--- a/Data/Aryx_AWE_CubeBlocks.sbc
+++ b/Data/Aryx_AWE_CubeBlocks.sbc
@@ -813,71 +813,7 @@
       <TargetingGroups>
       <string>Weapons</string>
       </TargetingGroups>      
-    </Definition> --><!-- <Definition xsi:type="MyObjectBuilder_ConveyorSorterDefinition">
-      <Id>
-        <TypeId>ConveyorSorter</TypeId>
-        <SubtypeId>ARYXRocketArtillery</SubtypeId>
-      </Id>
-      <DisplayName>RA-5 Starfall Rocket Artillery</DisplayName>
-      <Icon>Textures\GUI\Icons\Aryx_AWE_Starfall.dds</Icon>     
-      <Description>The Starfall is a heavy rocket battery designed for plunging fire that launches long-range nuclear missiles at extreme velocity, able to strike targets regardless of cover. The missiles disengage guidance during their final stage and accelerate to massive speeds, able to slip through PD screens and obliterate the delicate hull beneath. Hurricane on the roof; Armageddon on your doorstep. [15km range - Accepts Starfall Nuclear Missiles]
-     Effects: Fires five extremely fast and deadly missiles at enemies from long range.
-     Size: 9x10x9
-     Role: Capital Defence
-     Hardpoint: Full-traverse Turret
-     Type: Artillery Turret
-     </Description>
-         <CubeSize>Large</CubeSize>
-         <BlockTopology>TriangleMesh</BlockTopology>
-         <Size x="9" y="10" z="9"/>
-         <ModelOffset x="0" y="0" z="0"/>
-         <Model>Models\AWE_Starfall\ARYXRocketArtillery_Base.mwm</Model>
-      <Components>
-         <Component Subtype="SteelPlate" Count="7500" />
-         <Component Subtype="Construction" Count="4000" />
-         <Component Subtype="MetalGrid" Count="2000" />
-         <Component Subtype="LargeTube" Count="1000" />   
-         <Component Subtype="Motor" Count="800" />
-         <Component Subtype="Detector" Count="500" />
-         <Component Subtype="SuperchargerAWE" Count="100" />         
-         <Component Subtype="Computer" Count="1500" />
-         <Component Subtype="Construction" Count="3500" />
-         <Component Subtype="MetalGrid" Count="2000" />
-         <Component Subtype="MilitaryPlateAWE" Count="2500" />
-      </Components>
-      <CriticalComponent Index="0" Subtype="Computer"/>
-         <MountPoints>
-            <MountPoint Side="Front" StartX="0.00" StartY="0.00" EndX="9.00" EndY="3.00"/>
-            <MountPoint Side="Back" StartX="0.00" StartY="0.00" EndX="9.00" EndY="3.00"/>
-            <MountPoint Side="Left" StartX="0.00" StartY="0.00" EndX="9.00" EndY="3.00"/>
-            <MountPoint Side="Right" StartX="0.00" StartY="0.00" EndX="9.00" EndY="3.00"/>
-            <MountPoint Side="Bottom" StartX="0.00" StartY="0.00" EndX="9.00" EndY="9.00"/>
-         </MountPoints>
-         <BuildProgressModels>
-            <Model BuildPercentUpperBound="0.33" File="Models\AWE_Starfall\ARYXRocketArtillery_Base_BS1.mwm"/>
-            <Model BuildPercentUpperBound="0.67" File="Models\AWE_Starfall\ARYXRocketArtillery_Base_BS2.mwm"/>
-            <Model BuildPercentUpperBound="1.00" File="Models\AWE_Starfall\ARYXRocketArtillery_Base_BS3.mwm"/>
-         </BuildProgressModels>
-      <BlockPairName>ARYX_StarfallHIMARS</BlockPairName>
-      <MirroringY>Z</MirroringY>
-      <MirroringZ>Y</MirroringZ>
-      <BuildTimeSeconds>85</BuildTimeSeconds>
-     <GeneralDamageMultiplier>0.5</GeneralDamageMultiplier>
-      <EdgeType>Light</EdgeType>
-      < WeaponDefinitionId Subtype="AryxBurstCannonWepDef" \>
-     <OverlayTexture>Textures\GUI\Screens    urret_overlay.dds</OverlayTexture>          
-      <ResourceSinkGroup>Defense</ResourceSinkGroup>
-      <InventoryMaxVolume>0.48</InventoryMaxVolume>
-      <DamageEffectName>Damage_WeapExpl_Damaged</DamageEffectName>
-      <DamagedSound>ParticleWeapExpl</DamagedSound>
-      <DestroyEffect>BlockDestroyedExplosion_Small</DestroyEffect>
-      <DestroySound>WepSmallWarheadExpl</DestroySound>
-      <PCU>300</PCU>      
-      <TargetingGroups>
-      <string>Weapons</string>
-      </TargetingGroups>      
     </Definition> -->
-
    <!-- <Definition xsi:type="MyObjectBuilder_LargeTurretBaseDefinition">
       <Id>
         <TypeId>LargeMissileTurret</TypeId>
@@ -1317,10 +1253,6 @@
      Component Armor DPS per PCU: 4.1
      While not overheating, the true DPS values 
      are ~199% higher than listed above.
-     Switch to Bunker Buster ammo for these different stats:
-     Heavy Armor and Component DPS per PCU: 0
-     Shield Armor DPS per PCU: 120.0
-     Muzzle Velocity: 400m/s (800m Minimum Arming Time)
      </Description>
       <CubeSize>Large</CubeSize>
       <BlockTopology>TriangleMesh</BlockTopology>

--- a/Data/Scripts/CoreParts/AryxAutocannonEchoTurret_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxAutocannonEchoTurret_Weapon.cs
@@ -23,7 +23,7 @@ namespace Scripts
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 0.2f,
+                        DurabilityMod = 0.1f,
                     },
                     
                 },
@@ -166,6 +166,7 @@ namespace Scripts
             },
             Ammos = new [] {
                 AryxEchoHEAmmo,
+                AryxEchoHEBusterAmmo,
             },
             Animations = AryxEchoAnimations,
             // Don't edit below this line

--- a/Data/Scripts/CoreParts/AryxAutocannonEcho_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxAutocannonEcho_AmmoTypes.cs
@@ -774,5 +774,379 @@ namespace Scripts
             },
         };
 
+        private AmmoDef AryxEchoHEBusterAmmo => new AmmoDef
+        {
+            AmmoMagazine = "AWE85mmAmmoMagazine",
+            AmmoRound = "85mm Buster HE ECHO",
+            HybridRound = false, //AmmoMagazine based weapon with energy cost
+            EnergyCost = 0.0f, //(((EnergyCost * DefaultDamage) * ShotsPerSecond) * BarrelsPerShot) * ShotsPerBarrel
+            BaseDamage = 1,
+            Mass = 40f, // in kilograms
+            Health = 0, // 0 = disabled, otherwise how much damage it can take from other trajectiles before dying.
+            BackKickForce = 7000,
+            DecayPerShot = 0f,
+            HardPointUsable = true, // set to false if this is a shrapnel ammoType and you don't want the turret to be able to select it directly.
+            IgnoreWater = true,
+            Shape = new ShapeDef //defines the collision shape of projectile, defaults line and visual Line Length if set to 0
+            {
+                Shape = LineShape,
+                Diameter = 1,
+            },
+            ObjectsHit = new ObjectsHitDef
+            {
+                MaxObjectsHit = 1, // 0 = disabled
+                CountBlocks = true, // counts gridBlocks and not just entities hit
+            },
+            Fragment = new FragmentDef
+            {
+                AmmoRound = "",
+                Fragments = 20,
+                Degrees = 90,
+                Reverse = false,
+
+            },
+            Pattern = new PatternDef
+            {
+                Patterns = new[] {
+                    "",
+                },
+                Enable = false,
+                TriggerChance = 1f,
+                Random = false,
+                RandomMin = 1,
+                RandomMax = 1,
+                SkipParent = false,
+            },
+            DamageScales = new DamageScaleDef
+            {
+                MaxIntegrity = 0f, // 0 = disabled, 1000 = any blocks with currently integrity above 1000 will be immune to damage.
+                DamageVoxels = false, // true = voxels are vulnerable to this weapon
+                SelfDamage = false, // true = allow self damage.
+                HealthHitModifier = 6, // defaults to a value of 1, this setting modifies how much Health is subtracted from a projectile per hit (1 = per hit).
+                VoxelHitModifier = 1,
+                Characters = 65f,
+                FallOff = new FallOffDef
+                {
+                    Distance = 5000f, // Distance at which max damage begins falling off.
+                    MinMultipler = 1, // value from 0.0f to 1f where 0.1f would be a min damage of 10% of max damage.
+                },
+                Grids = new GridSizeDef
+                {
+                    Large = -1f,
+                    Small = -1f,
+                },
+                Armor = new ArmorDef
+                {
+                    Armor = 0.0001f,
+                    Light = -1f,
+                    Heavy = -1f,
+                    NonArmor = 0.0001f,
+                },
+                Shields = new ShieldDef
+                {
+                    Modifier = 60f,
+                    Type = Default,
+                    BypassModifier = -2f,
+                },
+                DamageType = new DamageTypes
+                {
+                    Base = Kinetic,
+                    AreaEffect = Kinetic,
+                    Detonation = Kinetic,
+                    Shield = Kinetic,
+                },
+                // first true/false (ignoreOthers) will cause projectiles to pass through all blocks that do not match the custom subtypeIds.
+                Custom = new CustomScalesDef
+                {
+                    IgnoreAllOthers = false,
+                    Types = new[]
+                    {
+                        new CustomBlocksDef
+                        {
+                            SubTypeId = "Test1",
+                            Modifier = -1f,
+                        },
+                        new CustomBlocksDef
+                        {
+                            SubTypeId = "Test2",
+                            Modifier = -1f,
+                        },
+                    },
+                },
+            },
+            AreaOfDamage = new AreaOfDamageDef
+            {
+                ByBlockHit = new ByBlockHitDef
+                {
+                    Enable = false,
+                    Radius = 0f, // Meters
+                    Damage = 0f,
+                    Depth = 1f, // Meters
+                    MaxAbsorb = 0f,
+                    Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius
+                    //.Linear drops evenly by distance from center out to max radius
+                    //.Curve drops off damage sharply as it approaches the max radius
+                    //.InvCurve drops off sharply from the middle and tapers to max radius
+                    //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
+                    //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
+                    Shape = Diamond, // Round or Diamond
+                },
+                EndOfLife = new EndOfLifeDef
+                {
+                    Enable = true,
+                    Radius = 2f, // Meters
+                    Damage = (float)(600 * AWEGlobalDamageScalar),
+                    Depth = 1f,
+                    MaxAbsorb = 0f,
+                    Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius
+                    //.Linear drops evenly by distance from center out to max radius
+                    //.Curve drops off damage sharply as it approaches the max radius
+                    //.InvCurve drops off sharply from the middle and tapers to max radius
+                    //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
+                    //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
+                    ArmOnlyOnHit = true, // Detonation only is available, After it hits something, when this is true. IE, if shot down, it won't explode.
+                    MinArmingTime = 90, // In ticks, before the Ammo is allowed to explode, detonate or similar; This affects shrapnel spawning.
+                    NoVisuals = false,
+                    NoSound = false,
+                    ParticleScale = 1,
+                    CustomParticle = "particleName", // Particle SubtypeID, from your Particle SBC
+                    CustomSound = "soundName", // SubtypeID from your Audio SBC, not a filename
+                    Shape = Diamond, // Round or Diamond
+                },
+            },
+            Ewar = new EwarDef
+            {
+                Enable = false, // Enables EWAR effects AND DISABLES BASE DAMAGE AND AOE DAMAGE!!
+                Type = EnergySink, // EnergySink, Emp, Offense, Nav, Dot, AntiSmart, JumpNull, Anchor, Tractor, Pull, Push, 
+                Mode = Effect, // Effect , Field
+                Strength = 100f,
+                Radius = 5f, // Meters
+                Duration = 100, // In Ticks
+                StackDuration = true, // Combined Durations
+                Depletable = true,
+                MaxStacks = 10, // Max Debuffs at once
+                NoHitParticle = false,
+                /*
+                EnergySink : Targets & Shutdowns Power Supplies, such as Batteries & Reactor
+                Emp : Targets & Shutdown any Block capable of being powered
+                Offense : Targets & Shutdowns Weaponry
+                Nav : Targets & Shutdown Gyros, Thrusters, or Locks them down
+                Dot : Deals Damage to Blocks in radius
+                AntiSmart : Effects & Scrambles the Targeting List of Affected Missiles
+                JumpNull : Shutdown & Stops any Active Jumps, or JumpDrive Units in radius
+                Tractor : Affects target with Physics
+                Pull : Affects target with Physics
+                Push : Affects target with Physics
+                Anchor : Affects target with Physics
+                
+                */
+                Force = new PushPullDef
+                {
+                    ForceFrom = ProjectileLastPosition, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    ForceTo = HitPosition, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    Position = TargetCenterOfMass, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    DisableRelativeMass = false,
+                    TractorRange = 0,
+                    ShooterFeelsForce = false,
+                },
+                Field = new FieldDef
+                {
+                    Interval = 0, // Time between each pulse, in game ticks (60 == 1 second).
+                    PulseChance = 0, // Chance from 0 - 100 that an entity in the field will be hit by any given pulse.
+                    GrowTime = 0, // How many ticks it should take the field to grow to full size.
+                    HideModel = false, // Hide the projectile model if it has one.
+                    ShowParticle = true, // Show Block damage effect.
+                    TriggerRange = 250f, //range at which fields are triggered
+                    Particle = new ParticleDef // Particle effect to generate at the field's position.
+                    {
+                        Name = "", // SubtypeId of field particle effect.
+                        Extras = new ParticleOptionDef
+                        {
+                            Scale = 1, // Scale of effect.
+                        },
+                    },
+                },
+            },
+            Beams = new BeamDef
+            {
+                Enable = false,
+                VirtualBeams = false, // Only one hot beam, but with the effectiveness of the virtual beams combined (better performace)
+                ConvergeBeams = false, // When using virtual beams this option visually converges the beams to the location of the real beam.
+                RotateRealBeam = false, // The real (hot beam) is rotated between all virtual beams, instead of centered between them.
+                OneParticle = false, // Only spawn one particle hit per beam weapon.
+            },
+            Trajectory = new TrajectoryDef
+            {
+                Guidance = None,
+                TargetLossDegree = 80f,
+                TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                AccelPerSec = 0f,
+                DesiredSpeed = 1000,
+                MaxTrajectory = 10000,
+                //FieldTime was here, it's dead now is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
+                GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
+                SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed
+                RangeVariance = Random(start: 0, end: 0), // subtracts value from MaxTrajectory
+                MaxTrajectoryTime = 0, // How long the weapon must fire before it reaches MaxTrajectory.
+                Smarts = new SmartsDef
+                {
+                    Inaccuracy = 0f, // 0 is perfect, hit accuracy will be a random num of meters between 0 and this value.
+                    Aggressiveness = 1f, // controls how responsive tracking is.
+                    MaxLateralThrust = 0.5, // controls how sharp the trajectile may turn
+                    TrackingDelay = 0, // Measured in Shape diameter units traveled.
+                    MaxChaseTime = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    OverideTarget = true, // when set to true ammo picks its own target, does not use hardpoint's.
+                    MaxTargets = 0, // Number of targets allowed before ending, 0 = unlimited
+                    NoTargetExpire = false, // Expire without ever having a target at TargetLossTime
+                    Roam = false, // Roam current area after target loss
+                    KeepAliveAfterTargetLoss = false, // Whether to stop early death of projectile on target loss
+                },
+                Mines = new MinesDef
+                {
+                    DetectRadius = 0,
+                    DeCloakRadius = 0,
+                    FieldTime = 0,
+                    Cloak = false,
+                    Persist = false,
+                },
+            },
+            AmmoGraphics = new GraphicDef
+            {
+                ModelName = "",
+                VisualProbability = 1f,
+                ShieldHitDraw = true,
+                Particles = new AmmoParticleDef
+                {
+                    Ammo = new ParticleDef
+                    {
+                        Name = "", //ShipWelderArc
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 128, green: 0, blue: 0, alpha: 32),
+                        Offset = Vector(x: 0, y: -1, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Loop = false,
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 1,
+                            Scale = 1,
+                        },
+                    },
+                    Hit = new ParticleDef
+                    {
+                        Name = "MaterialHit_Metal_GatlingGun",
+                        ApplyToShield = true,
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 3, green: 1.9f, blue: 1f, alpha: 1),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Loop = false,
+                            Restart = false,
+                            MaxDistance = 100,
+                            MaxDuration = 0,
+                            Scale = 3,
+                            HitPlayChance = 1f,
+                        },
+                    },
+                    Eject = new ParticleDef
+                    {
+                        Name = "",
+                        ApplyToShield = true,
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 3, green: 1.9f, blue: 1f, alpha: 1),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Loop = false,
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 30,
+                            Scale = 1,
+                            HitPlayChance = 1f,
+                        },
+                    },
+                },
+                Lines = new LineDef
+                {
+                    ColorVariance = Random(start: 0.75f, end: 2f), // multiply the color by random values within range.
+                    WidthVariance = Random(start: 0f, end: 0f), // adds random value to default width (negatives shrinks width)
+                    Tracer = new TracerBaseDef
+                    {
+                        Enable = true,
+                        Length = 20f,
+                        Width = 0.45f,
+                        Color = Color(red: 23, green: 9, blue: 1, alpha: 1),
+                        VisualFadeStart = 0, // Number of ticks the weapon has been firing before projectiles begin to fade their color
+                        VisualFadeEnd = 0, // How many ticks after fade began before it will be invisible.
+                        Textures = new[] {// WeaponLaser, ProjectileTrailLine, WarpBubble, etc..
+                            "AryxBallisticTracer",
+                        },
+                        TextureMode = Normal, // Normal, Cycle, Chaos, Wave
+                        Segmentation = new SegmentDef
+                        {
+                            Enable = false, // If true Tracer TextureMode is ignored
+                            Textures = new[] {
+                                "AryxBallisticTracer",
+                            },
+                            SegmentLength = 0f, // Uses the values below.
+                            SegmentGap = 0f, // Uses Tracer textures and values
+                            Speed = 1f, // meters per second
+                            Color = Color(red: 1, green: 2, blue: 2.5f, alpha: 1),
+                            WidthMultiplier = 1f,
+                            Reverse = false,
+                            UseLineVariance = true,
+                            WidthVariance = Random(start: 0f, end: 0f),
+                            ColorVariance = Random(start: 0f, end: 0f)
+                        }
+                    },
+                    Trail = new TrailDef
+                    {
+                        Enable = false,
+                        Textures = new[] {
+                            "AryxBallisticTracer",
+                        },
+                        TextureMode = Normal,
+                        DecayTime = 128,
+                        Color = Color(red: 0, green: 0, blue: 1, alpha: 1),
+                        Back = false,
+                        CustomWidth = 0,
+                        UseWidthVariance = false,
+                        UseColorFade = true,
+                    },
+                    OffsetEffect = new OffsetEffectDef
+                    {
+                        MaxOffset = 0,// 0 offset value disables this effect
+                        MinLength = 0.2f,
+                        MaxLength = 3,
+                    },
+                },
+            },
+            AmmoAudio = new AmmoAudioDef
+            {
+                TravelSound = "",
+                HitSound = "",
+                ShieldHitSound = "",
+                PlayerHitSound = "",
+                VoxelHitSound = "",
+                FloatingHitSound = "",
+                HitPlayChance = 0.5f,
+                HitPlayShield = true,
+            }, // Don't edit below this line
+            Ejection = new EjectionDef
+            {
+                Type = Particle, // Particle or Item (Inventory Component)
+                Speed = 100f, // Speed inventory is ejected from in dummy direction
+                SpawnChance = 0.5f, // chance of triggering effect (0 - 1)
+                CompDef = new ComponentDef
+                {
+                    ItemName = "", //InventoryComponent name
+                    ItemLifeTime = 0, // how long item should exist in world
+                    Delay = 0, // delay in ticks after shot before ejected
+                }
+            },
+        };
+
     }
 }

--- a/Data/Scripts/CoreParts/AryxBattleCyclone_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxBattleCyclone_Weapon.cs
@@ -25,7 +25,7 @@ namespace Scripts
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 0.25f,
+                        DurabilityMod = 0.125f,
                     },
                     new MountPointDef {
                         SubtypeId = "ARYXCycloneCannon_SG",
@@ -33,7 +33,7 @@ namespace Scripts
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 0.25f,
+                        DurabilityMod = 0.125f,
                     },
                 },
                 Muzzles = new[] {

--- a/Data/Scripts/CoreParts/AryxBattleHurricane_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxBattleHurricane_Weapon.cs
@@ -25,7 +25,7 @@ namespace Scripts
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 1.25f,
+                        DurabilityMod = 0.5f,
                     },
                 },
                 Muzzles = new[] {

--- a/Data/Scripts/CoreParts/AryxBattleTempest_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxBattleTempest_Weapon.cs
@@ -25,7 +25,7 @@ namespace Scripts
                         MuzzlePartId = "None",
                         AzimuthPartId = "None",
                         ElevationPartId = "None",
-                        DurabilityMod = 1.0f,
+                        DurabilityMod = 0.5f,
                     },
                     new MountPointDef {
                         SubtypeId = "ARYXTempestCannon_SG",
@@ -33,7 +33,7 @@ namespace Scripts
                         MuzzlePartId = "None",
                         AzimuthPartId = "None",
                         ElevationPartId = "None",
-                        DurabilityMod = 1.0f,
+                        DurabilityMod = 0.5f,
                     },
                 },
                 Muzzles = new[] {

--- a/Data/Scripts/CoreParts/AryxBattleTyphoon_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxBattleTyphoon_Weapon.cs
@@ -24,7 +24,7 @@ namespace Scripts
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 2.0f,
+                        DurabilityMod = 0.667f,
                     },
 
                 },

--- a/Data/Scripts/CoreParts/AryxBurstPunisher_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxBurstPunisher_AmmoTypes.cs
@@ -85,8 +85,8 @@ namespace Scripts
                 },
                 Armor = new ArmorDef
                 {
-                    Armor = -1f,
-                    Light = 1.5f,
+                    Armor = 1.5f,
+                    Light = -1f,
                     Heavy = -1f,
                     NonArmor = -1f,
                 },
@@ -231,6 +231,373 @@ namespace Scripts
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
                 DesiredSpeed = 2400, // voxel phasing if you go above 5100
+                MaxTrajectory = 6000f,
+                //FieldTime was here, it's dead now is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
+                GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
+                SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed
+                RangeVariance = Random(start: 0, end: 0), // subtracts value from MaxTrajectory
+                MaxTrajectoryTime = 0, // How long the weapon must fire before it reaches MaxTrajectory.
+                Smarts = new SmartsDef
+                {
+                    Inaccuracy = 0f, // 0 is perfect, hit accuracy will be a random num of meters between 0 and this value.
+                    Aggressiveness = 1f, // controls how responsive tracking is.
+                    MaxLateralThrust = 0.5, // controls how sharp the trajectile may turn
+                    TrackingDelay = 0, // Measured in Shape diameter units traveled.
+                    MaxChaseTime = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    OverideTarget = true, // when set to true ammo picks its own target, does not use hardpoint's.
+                    MaxTargets = 0, // Number of targets allowed before ending, 0 = unlimited
+                    NoTargetExpire = false, // Expire without ever having a target at TargetLossTime
+                    Roam = false, // Roam current area after target loss
+                    KeepAliveAfterTargetLoss = false, // Whether to stop early death of projectile on target loss
+                },
+                Mines = new MinesDef
+                {
+                    DetectRadius = 0,
+                    DeCloakRadius = 0,
+                    FieldTime = 0,
+                    Cloak = false,
+                    Persist = false,
+                },
+            },
+            AmmoGraphics = new GraphicDef
+            {
+                ModelName = "",
+                VisualProbability = 1f,
+                ShieldHitDraw = false,
+                Particles = new AmmoParticleDef
+                {
+                    Ammo = new ParticleDef
+                    {
+                        Name = "", //ShipWelderArc
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 128, green: 0, blue: 0, alpha: 32),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 0,
+                            Scale = 1,
+                        },
+                    },
+                    Hit = new ParticleDef
+                    {
+                        Name = "AWE_LowCalHit",
+                        ApplyToShield = true,
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 25, green: 10f, blue: 1f, alpha: 1),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 0,
+                            Scale = 1,
+                            HitPlayChance = 1f,
+                        },
+                    },
+                    Eject = new ParticleDef
+                    {
+                        Name = "",
+                        ApplyToShield = true,
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 3, green: 1.9f, blue: 1f, alpha: 1),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 30,
+                            Scale = 1,
+                            HitPlayChance = 1f,
+                        },
+                    },
+                },
+                Lines = new LineDef
+                {
+                    ColorVariance = Random(start: 0.75f, end: 2f), // multiply the color by random values within range.
+                    WidthVariance = Random(start: 0f, end: 0f), // adds random value to default width (negatives shrinks width)
+                    Tracer = new TracerBaseDef
+                    {
+                        Enable = true,
+                        Length = 25f,
+                        Width = 0.5f,
+                        Color = Color(red: 25, green: 5, blue: 1, alpha: 1),
+                        VisualFadeStart = 0, // Number of ticks the weapon has been firing before projectiles begin to fade their color
+                        VisualFadeEnd = 0, // How many ticks after fade began before it will be invisible.
+                        Textures = new[] {// WeaponLaser, ProjectileTrailLine, WarpBubble, etc..
+                            "AryxBallisticTracer",
+                        },
+                        TextureMode = Normal, // Normal, Cycle, Chaos, Wave
+                        Segmentation = new SegmentDef
+                        {
+                            Enable = false, // If true Tracer TextureMode is ignored
+                            Textures = new[] {
+                                "AryxBallisticTracer",
+                            },
+                            SegmentLength = 0f, // Uses the values below.
+                            SegmentGap = 0f, // Uses Tracer textures and values
+                            Speed = 1f, // meters per second
+                            Color = Color(red: 1, green: 2, blue: 2.5f, alpha: 1),
+                            WidthMultiplier = 1f,
+                            Reverse = false,
+                            UseLineVariance = true,
+                            WidthVariance = Random(start: 0f, end: 0f),
+                            ColorVariance = Random(start: 0f, end: 0f)
+                        }
+                    },
+                    Trail = new TrailDef
+                    {
+                        Enable = false,
+                        Textures = new[] {
+                            "AryxBallisticTracer",
+                        },
+                        TextureMode = Normal,
+                        DecayTime = 128,
+                        Color = Color(red: 0, green: 0, blue: 1, alpha: 1),
+                        Back = false,
+                        CustomWidth = 0,
+                        UseWidthVariance = false,
+                        UseColorFade = true,
+                    },
+                    OffsetEffect = new OffsetEffectDef
+                    {
+                        MaxOffset = 0,// 0 offset value disables this effect
+                        MinLength = 0.2f,
+                        MaxLength = 3,
+                    },
+                },
+            },
+            AmmoAudio = new AmmoAudioDef
+            {
+                TravelSound = "",
+                HitSound = "ArcWepShipARYX_RocketExplosion",
+                ShieldHitSound = "",
+                PlayerHitSound = "",
+                VoxelHitSound = "",
+                FloatingHitSound = "",
+                HitPlayChance = 0.5f,
+                HitPlayShield = true,
+            }, // Don't edit below this line
+            Ejection = new EjectionDef
+            {
+                Type = Particle, // Particle or Item (Inventory Component)
+                Speed = 100f, // Speed inventory is ejected from in dummy direction
+                SpawnChance = 0.5f, // chance of triggering effect (0 - 1)
+                CompDef = new ComponentDef
+                {
+                    ItemName = "", //InventoryComponent name
+                    ItemLifeTime = 0, // how long item should exist in world
+                    Delay = 0, // delay in ticks after shot before ejected
+                }
+            },
+        };
+
+        private AmmoDef AryxHEBusterAmmoWC => new AmmoDef
+        {
+            AmmoMagazine = "70mmBurstMag", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo
+            AmmoRound = "Punisher Buster HE 70mm", // name of ammo in terminal, should be unique for each ammo type. Used for Name field in server config
+            HybridRound = false, //AmmoMagazine based weapon with energy cost
+            EnergyCost = 0.00000000001f, //(((EnergyCost * DefaultDamage) * ShotsPerSecond) * BarrelsPerShot) * ShotsPerBarrel
+            BaseDamage = (float)(1 * AWEGlobalDamageScalar),
+            Mass = 50f, // in kilograms
+            Health = 0, // 0 = disabled, otherwise how much damage it can take from other trajectiles before dying.
+            BackKickForce = 5250f,
+            DecayPerShot = 0f,
+            HardPointUsable = true, // set to false if this is a shrapnel ammoType and you don't want the turret to be able to select it directly.
+            EnergyMagazineSize = 0,
+            IgnoreWater = false,
+
+            Shape = new ShapeDef //defines the collision shape of projectile, defaults line and visual Line Length if set to 0
+            {
+                Shape = LineShape, // LineShape or SphereShape. Do not use SphereShape for fast moving projectiles if you care about precision.
+                Diameter = 1, // Diameter is minimum length of LineShape or minimum diameter of SphereShape
+            },
+            ObjectsHit = new ObjectsHitDef
+            {
+                MaxObjectsHit = 0, // 0 = disabled
+                CountBlocks = false, // counts gridBlocks and not just entities hit
+            },
+            Pattern = new PatternDef
+            {
+                Patterns = new[] {
+                    "",
+                },
+                Enable = false,
+                TriggerChance = 1f,
+                Random = false,
+                RandomMin = 1,
+                RandomMax = 1,
+                SkipParent = false,
+                PatternSteps = 1, // Number of Ammos activated per round, will progress in order and loop.  Ignored if Random = true.
+            },
+            DamageScales = new DamageScaleDef
+            {
+                MaxIntegrity = 0f, // 0 = disabled, 1000 = any blocks with currently integrity above 1000 will be immune to damage.
+                DamageVoxels = false, // true = voxels are vulnerable to this weapon
+                SelfDamage = false, // true = allow self damage.
+                HealthHitModifier = 0.5, // defaults to a value of 1, this setting modifies how much Health is subtracted from a projectile per hit (1 = per hit).
+                VoxelHitModifier = 1,
+                Characters = -1f,
+                // modifier values: -1 = disabled (higher performance), 0 = no damage, 0.01 = 1% damage, 2 = 200% damage.
+                FallOff = new FallOffDef
+                {
+                    Distance = 1000f, // Distance at which max damage begins falling off.
+                    MinMultipler = 1f, // value from 0.0001f to 1f where 0.1f would be a min damage of 10% of max damage.
+                },
+                Grids = new GridSizeDef
+                {
+                    Large = -1f,
+                    Small = -1f,
+                },
+                Armor = new ArmorDef
+                {
+                    Armor = 0.0001f,
+                    Light = -1f,
+                    Heavy = -1f,
+                    NonArmor = 0.0001f,
+                },
+                Shields = new ShieldDef
+                {
+                    Modifier = 10f,
+                    Type = Default, // Default, Heal
+                    BypassModifier = -2f,
+                },
+                DamageType = new DamageTypes
+                {
+                    Base = Kinetic,
+                    AreaEffect = Kinetic,
+                    Detonation = Kinetic,
+                    Shield = Kinetic,
+                },
+                // first true/false (ignoreOthers) will cause projectiles to pass through all blocks that do not match the custom subtypeIds.
+                Custom = new CustomScalesDef
+                {
+                    IgnoreAllOthers = false,
+                    Types = new[]
+                    {
+                        new CustomBlocksDef
+                        {
+                            SubTypeId = "Test1",
+                            Modifier = -1f,
+                        },
+                        new CustomBlocksDef
+                        {
+                            SubTypeId = "Test2",
+                            Modifier = -1f,
+                        },
+                    },
+                },
+            },
+			AreaOfDamage = new AreaOfDamageDef
+            {
+                ByBlockHit = new ByBlockHitDef
+                {
+                    Enable = false,
+                    Radius = 0f, // Meters
+                    Damage = 0,
+                    Depth = 1f, // Meters
+                    MaxAbsorb = 0f,
+                    Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius
+                    //.Linear drops evenly by distance from center out to max radius
+                    //.Curve drops off damage sharply as it approaches the max radius
+                    //.InvCurve drops off sharply from the middle and tapers to max radius
+                    //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
+                    //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
+                    Shape = Diamond, // Round or Diamond
+                },
+                EndOfLife = new EndOfLifeDef
+                {
+                    Enable = true,
+                    Radius = 1f, // Meters
+                    Damage = (float)(3750 * AWEGlobalDamageScalar),
+                    Depth = 1f,
+                    MaxAbsorb = 0f,
+                    Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius
+                    //.Linear drops evenly by distance from center out to max radius
+                    //.Curve drops off damage sharply as it approaches the max radius
+                    //.InvCurve drops off sharply from the middle and tapers to max radius
+                    //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
+                    //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
+                    ArmOnlyOnHit = false, // Detonation only is available after it hits something, when this is true. IE, if shot down, it won't explode.
+                    MinArmingTime = 120, // In ticks, before the Ammo is allowed to explode, detonate or similar; This affects shrapnel spawning.
+                    NoVisuals = false,
+                    NoSound = false,
+                    ParticleScale = 1,
+                    CustomParticle = "AWE_FlakBlast", // Particle SubtypeID, from your Particle SBC
+                    CustomSound = "ArcWepShipARYX_RocketExplosion", // SubtypeID from your Audio SBC, not a filename
+                    Shape = Diamond, // Round or Diamond
+                }, 
+            },
+            Ewar = new EwarDef
+            {
+                Enable = false, // Enables EWAR effects AND DISABLES BASE DAMAGE AND AOE DAMAGE!!
+                Type = EnergySink, // EnergySink, Emp, Offense, Nav, Dot, AntiSmart, JumpNull, Anchor, Tractor, Pull, Push, 
+                Mode = Effect, // Effect , Field
+                Strength = 100f,
+                Radius = 5f, // Meters
+                Duration = 100, // In Ticks
+                StackDuration = true, // Combined Durations
+                Depletable = true,
+                MaxStacks = 10, // Max Debuffs at once
+                NoHitParticle = false,
+                /*
+                EnergySink : Targets & Shutdowns Power Supplies, such as Batteries & Reactor
+                Emp : Targets & Shutdown any Block capable of being powered
+                Offense : Targets & Shutdowns Weaponry
+                Nav : Targets & Shutdown Gyros, Thrusters, or Locks them down
+                Dot : Deals Damage to Blocks in radius
+                AntiSmart : Effects & Scrambles the Targeting List of Affected Missiles
+                JumpNull : Shutdown & Stops any Active Jumps, or JumpDrive Units in radius
+                Tractor : Affects target with Physics
+                Pull : Affects target with Physics
+                Push : Affects target with Physics
+                Anchor : Affects target with Physics
+                
+                */
+                Force = new PushPullDef
+                {
+                    ForceFrom = ProjectileLastPosition, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    ForceTo = HitPosition, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    Position = TargetCenterOfMass, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    DisableRelativeMass = false,
+                    TractorRange = 0,
+                    ShooterFeelsForce = false,
+                },
+                Field = new FieldDef
+                {
+                    Interval = 0, // Time between each pulse, in game ticks (60 == 1 second).
+                    PulseChance = 0, // Chance from 0 - 100 that an entity in the field will be hit by any given pulse.
+                    GrowTime = 0, // How many ticks it should take the field to grow to full size.
+                    HideModel = false, // Hide the projectile model if it has one.
+                    ShowParticle = true, // Show Block damage effect.
+                    TriggerRange = 250f, //range at which fields are triggered
+                    Particle = new ParticleDef // Particle effect to generate at the field's position.
+                    {
+                        Name = "", // SubtypeId of field particle effect.
+                        Extras = new ParticleOptionDef
+                        {
+                            Scale = 1, // Scale of effect.
+                        },
+                    },
+                },
+            },
+            Beams = new BeamDef
+            {
+                Enable = false,
+                VirtualBeams = false, // Only one hot beam, but with the effectiveness of the virtual beams combined (better performace)
+                ConvergeBeams = false, // When using virtual beams this option visually converges the beams to the location of the real beam.
+                RotateRealBeam = false, // The real (hot beam) is rotated between all virtual beams, instead of centered between them.
+                OneParticle = false, // Only spawn one particle hit per beam weapon.
+            },
+            Trajectory = new TrajectoryDef
+            {
+                Guidance = None,
+                TargetLossDegree = 80f,
+                TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                AccelPerSec = 0f,
+                DesiredSpeed = 800, // voxel phasing if you go above 5100
                 MaxTrajectory = 6000f,
                 //FieldTime was here, it's dead now is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.

--- a/Data/Scripts/CoreParts/AryxBurstPunisher_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxBurstPunisher_Weapon.cs
@@ -23,7 +23,7 @@ namespace Scripts {
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 0.2f,
+                        DurabilityMod = 0.15f,
                     },
                     new MountPointDef {
                         SubtypeId = "ARYXBurstTurretSlanted",
@@ -31,7 +31,7 @@ namespace Scripts {
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 0.2f,
+                        DurabilityMod = 0.15f,
                     },
                     new MountPointDef {
                         SubtypeId = "ARYXBurstTurret_SG",
@@ -39,7 +39,7 @@ namespace Scripts {
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 0.2f,
+                        DurabilityMod = 0.15f,
                     },
                 },
                 Muzzles = new[] {
@@ -197,6 +197,7 @@ namespace Scripts {
             },
             Ammos = new[] {
                 AryxHEBurstAmmoWC,
+                AryxHEBusterAmmoWC,
             },
             //Animations = Weapon75_Animation,
             //Upgrades = UpgradeModules,

--- a/Data/Scripts/CoreParts/AryxCoilgunPredator_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxCoilgunPredator_Weapon.cs
@@ -24,7 +24,7 @@ namespace Scripts
                         MuzzlePartId = "None",
                         AzimuthPartId = "None",
                         ElevationPartId = "None",
-                        DurabilityMod = 1.25f,
+                        DurabilityMod = 0.75f,
                     },
 
                 },

--- a/Data/Scripts/CoreParts/AryxEnergyCannonMagnetar_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxEnergyCannonMagnetar_AmmoTypes.cs
@@ -29,7 +29,7 @@ namespace Scripts
         private AmmoDef AryxMagnetarAmmo => new AmmoDef
         {
             AmmoMagazine = "Energy", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo
-            AmmoRound = "Quasar Energy Bolt", // name of ammo in terminal, should be unique for each ammo type. Used for Name field in server config
+            AmmoRound = "Magnetar Energy Bolt", // name of ammo in terminal, should be unique for each ammo type. Used for Name field in server config
             HybridRound = false, //AmmoMagazine based weapon with energy cost
             EnergyCost = 0.149995f, //(((EnergyCost * DefaultDamage) * ShotsPerSecond) * BarrelsPerShot) * ShotsPerBarrel
             BaseDamage = (float)(10 * AWEGlobalDamageScalar),
@@ -330,6 +330,381 @@ namespace Scripts
                         Enable = true,
                         Length = 25f,
                         Width = 0.35f,
+                        Color = Color(red: 10, green: 25, blue: 50, alpha: 1),
+                        VisualFadeStart = 0, // Number of ticks the weapon has been firing before projectiles begin to fade their color
+                        VisualFadeEnd = 0, // How many ticks after fade began before it will be invisible.
+                        Textures = new[] {// WeaponLaser, ProjectileTrailLine, WarpBubble, etc..
+                            "AryxBallisticTracer",
+                        },
+                        TextureMode = Normal, // Normal, Cycle, Chaos, Wave
+                        Segmentation = new SegmentDef
+                        {
+                            Enable = false, // If true Tracer TextureMode is ignored
+                            Textures = new[] {
+                                "",
+                            },
+                            SegmentLength = 0f, // Uses the values below.
+                            SegmentGap = 0f, // Uses Tracer textures and values
+                            Speed = 1f, // meters per second
+                            Color = Color(red: 1, green: 2, blue: 2.5f, alpha: 1),
+                            WidthMultiplier = 1f,
+                            Reverse = false,
+                            UseLineVariance = true,
+                            WidthVariance = Random(start: 0f, end: 0f),
+                            ColorVariance = Random(start: 0f, end: 0f)
+                        }
+                    },
+                    Trail = new TrailDef
+                    {
+                        Enable = true,
+                        Textures = new[] {
+                            "WeaponLaser",
+                        },
+                        TextureMode = Normal,
+                        DecayTime = 60,
+                        Color = Color(red: 0, green: 0, blue: 1, alpha: 1),
+                        Back = false,
+                        CustomWidth = 0.15f,
+                        UseWidthVariance = false,
+                        UseColorFade = true,
+                    },
+                    OffsetEffect = new OffsetEffectDef
+                    {
+                        MaxOffset = 0,// 0 offset value disables this effect
+                        MinLength = 0.2f,
+                        MaxLength = 3,
+                    },
+                },
+            },
+            AmmoAudio = new AmmoAudioDef
+            {
+                TravelSound = "",
+                HitSound = "",
+                ShieldHitSound = "",
+                PlayerHitSound = "",
+                VoxelHitSound = "",
+                FloatingHitSound = "",
+                HitPlayChance = 0.5f,
+                HitPlayShield = true,
+            }, // Don't edit below this line
+            Ejection = new EjectionDef
+            {
+                Type = Particle, // Particle or Item (Inventory Component)
+                Speed = 100f, // Speed inventory is ejected from in dummy direction
+                SpawnChance = 0.5f, // chance of triggering effect (0 - 1)
+                CompDef = new ComponentDef
+                {
+                    ItemName = "", //InventoryComponent name
+                    ItemLifeTime = 0, // how long item should exist in world
+                    Delay = 0, // delay in ticks after shot before ejected
+                }
+            },
+        };
+
+        private AmmoDef AryxMagnetarBusterAmmo => new AmmoDef
+        {
+            AmmoMagazine = "Energy", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo
+            AmmoRound = "Magnetar Bunker Buster Energy Bolt", // name of ammo in terminal, should be unique for each ammo type. Used for Name field in server config
+            HybridRound = false, //AmmoMagazine based weapon with energy cost
+            EnergyCost = 0.149995f, //(((EnergyCost * DefaultDamage) * ShotsPerSecond) * BarrelsPerShot) * ShotsPerBarrel
+            BaseDamage = (float)(1 * AWEGlobalDamageScalar),
+            Mass = 0f, // in kilograms
+            Health = 0, // 0 = disabled, otherwise how much damage it can take from other trajectiles before dying.
+            BackKickForce = 0f,
+            DecayPerShot = 0f,
+            HardPointUsable = true, // set to false if this is a shrapnel ammoType and you don't want the turret to be able to select it directly.
+            EnergyMagazineSize = 3,
+            IgnoreWater = false,
+
+            Shape = new ShapeDef //defines the collision shape of projectile, defaults line and visual Line Length if set to 0
+            {
+                Shape = LineShape, // LineShape or SphereShape. Do not use SphereShape for fast moving projectiles if you care about precision.
+                Diameter = 1, // Diameter is minimum length of LineShape or minimum diameter of SphereShape
+            },
+            ObjectsHit = new ObjectsHitDef
+            {
+                MaxObjectsHit = 1, // 0 = disabled
+                CountBlocks = true, // counts gridBlocks and not just entities hit
+            },
+            Fragment = new FragmentDef
+            {
+                AmmoRound = "",
+                Fragments = 100,
+                Degrees = 15,
+                Reverse = false,
+                
+            },
+            Pattern = new PatternDef
+            {
+                Patterns = new[] {
+                    "",
+                },
+                Enable = false,
+                TriggerChance = 1f,
+                Random = false,
+                RandomMin = 1,
+                RandomMax = 1,
+                SkipParent = false,
+                PatternSteps = 1, // Number of Ammos activated per round, will progress in order and loop.  Ignored if Random = true.
+            },
+            DamageScales = new DamageScaleDef
+            {
+                MaxIntegrity = 0f, // 0 = disabled, 1000 = any blocks with currently integrity above 1000 will be immune to damage.
+                DamageVoxels = false, // true = voxels are vulnerable to this weapon
+                SelfDamage = false, // true = allow self damage.
+                HealthHitModifier = 0.5, // defaults to a value of 1, this setting modifies how much Health is subtracted from a projectile per hit (1 = per hit).
+                VoxelHitModifier = 1,
+                Characters = -1f,
+                // modifier values: -1 = disabled (higher performance), 0 = no damage, 0.01 = 1% damage, 2 = 200% damage.
+                FallOff = new FallOffDef
+                {
+                    Distance = 5000f, // Distance at which max damage begins falling off.
+                    MinMultipler = 1f, // value from 0.0001f to 1f where 0.1f would be a min damage of 10% of max damage.
+                },
+                Grids = new GridSizeDef
+                {
+                    Large = -1f,
+                    Small = 0.2f,
+                },
+                Armor = new ArmorDef
+                {
+                    Armor = 0.0001f,
+                    Light = -1f,
+                    Heavy = -1f,
+                    NonArmor = 0.0001f,
+                },
+                Shields = new ShieldDef
+                {
+                    Modifier = 50f,
+                    Type = Default, // Default, Heal
+                    BypassModifier = -2f,
+                },
+                DamageType = new DamageTypes
+                {
+                    Base = Energy,
+                    AreaEffect = Energy,
+                    Detonation = Energy,
+                    Shield = Energy,
+                },
+                // first true/false (ignoreOthers) will cause projectiles to pass through all blocks that do not match the custom subtypeIds.
+                Custom = new CustomScalesDef
+                {
+                    IgnoreAllOthers = false,
+                    Types = new[]
+                    {
+                        new CustomBlocksDef
+                        {
+                            SubTypeId = "Test1",
+                            Modifier = -1f,
+                        },
+                        new CustomBlocksDef
+                        {
+                            SubTypeId = "Test2",
+                            Modifier = -1f,
+                        },
+                    },
+                },
+            },
+			AreaOfDamage = new AreaOfDamageDef
+            {
+                ByBlockHit = new ByBlockHitDef
+                {
+                    Enable = false,
+                    Radius = 5f, // Meters
+                    Damage = (float)(6900 * AWEGlobalDamageScalar),
+                    Depth = 3f, // Meters
+                    MaxAbsorb = 0f,
+                    Falloff = Linear, //.NoFalloff applies the same damage to all blocks in radius
+                    //.Linear drops evenly by distance from center out to max radius
+                    //.Curve drops off damage sharply as it approaches the max radius
+                    //.InvCurve drops off sharply from the middle and tapers to max radius
+                    //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
+                    //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
+                    Shape = Diamond, // Round or Diamond
+                },
+                EndOfLife = new EndOfLifeDef
+                {
+                    Enable = true,
+                    Radius = 7f, // Meters
+                    Damage = (float)(10000 * AWEGlobalDamageScalar),
+                    Depth = 4f,
+                    MaxAbsorb = 0f,
+                    Falloff = Linear, //.NoFalloff applies the same damage to all blocks in radius
+                    //.Linear drops evenly by distance from center out to max radius
+                    //.Curve drops off damage sharply as it approaches the max radius
+                    //.InvCurve drops off sharply from the middle and tapers to max radius
+                    //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
+                    //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
+                    ArmOnlyOnHit = false, // Detonation only is available, After it hits something, when this is true. IE, if shot down, it won't explode.
+                    MinArmingTime = 120, // In ticks, before the Ammo is allowed to explode, detonate or similar; This affects shrapnel spawning.
+                    NoVisuals = false,
+                    NoSound = false,
+                    ParticleScale = 1,
+                    CustomParticle = "AWE_Shockcannon_Explosion", // Particle SubtypeID, from your Particle SBC
+                    CustomSound = "ArcWepShipARYX_ShockCannonHit", // SubtypeID from your Audio SBC, not a filename
+                    Shape = Round, // Round or Diamond
+                }, 
+            },
+            Ewar = new EwarDef
+            {
+                Enable = false, // Enables EWAR effects AND DISABLES BASE DAMAGE AND AOE DAMAGE!!
+                Type = EnergySink, // EnergySink, Emp, Offense, Nav, Dot, AntiSmart, JumpNull, Anchor, Tractor, Pull, Push, 
+                Mode = Effect, // Effect , Field
+                Strength = 100f,
+                Radius = 5f, // Meters
+                Duration = 100, // In Ticks
+                StackDuration = true, // Combined Durations
+                Depletable = true,
+                MaxStacks = 10, // Max Debuffs at once
+                NoHitParticle = false,
+                /*
+                EnergySink : Targets & Shutdowns Power Supplies, such as Batteries & Reactor
+                Emp : Targets & Shutdown any Block capable of being powered
+                Offense : Targets & Shutdowns Weaponry
+                Nav : Targets & Shutdown Gyros, Thrusters, or Locks them down
+                Dot : Deals Damage to Blocks in radius
+                AntiSmart : Effects & Scrambles the Targeting List of Affected Missiles
+                JumpNull : Shutdown & Stops any Active Jumps, or JumpDrive Units in radius
+                Tractor : Affects target with Physics
+                Pull : Affects target with Physics
+                Push : Affects target with Physics
+                Anchor : Affects target with Physics
+                
+                */
+                Force = new PushPullDef
+                {
+                    ForceFrom = ProjectileLastPosition, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    ForceTo = HitPosition, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    Position = TargetCenterOfMass, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    DisableRelativeMass = false,
+                    TractorRange = 0,
+                    ShooterFeelsForce = false,
+                },
+                Field = new FieldDef
+                {
+                    Interval = 0, // Time between each pulse, in game ticks (60 == 1 second).
+                    PulseChance = 0, // Chance from 0 - 100 that an entity in the field will be hit by any given pulse.
+                    GrowTime = 0, // How many ticks it should take the field to grow to full size.
+                    HideModel = false, // Hide the projectile model if it has one.
+                    ShowParticle = true, // Show Block damage effect.
+                    TriggerRange = 250f, //range at which fields are triggered
+                    Particle = new ParticleDef // Particle effect to generate at the field's position.
+                    {
+                        Name = "", // SubtypeId of field particle effect.
+                        Extras = new ParticleOptionDef
+                        {
+                            Scale = 1, // Scale of effect.
+                        },
+                    },
+                },
+            },
+            Beams = new BeamDef
+            {
+                Enable = false,
+                VirtualBeams = false, // Only one hot beam, but with the effectiveness of the virtual beams combined (better performace)
+                ConvergeBeams = false, // When using virtual beams this option visually converges the beams to the location of the real beam.
+                RotateRealBeam = false, // The real (hot beam) is rotated between all virtual beams, instead of centered between them.
+                OneParticle = false, // Only spawn one particle hit per beam weapon.
+            },
+            Trajectory = new TrajectoryDef
+            {
+                Guidance = None,
+                TargetLossDegree = 80f,
+                TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                AccelPerSec = 0f,
+                DesiredSpeed = 1000, // voxel phasing if you go above 5100
+                MaxTrajectory = 10000,
+                //FieldTime was here, it's dead now is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
+                GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
+                SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed
+                RangeVariance = Random(start: 0, end: 0), // subtracts value from MaxTrajectory
+                MaxTrajectoryTime = 0, // How long the weapon must fire before it reaches MaxTrajectory.
+                Smarts = new SmartsDef
+                {
+                    Inaccuracy = 0f, // 0 is perfect, hit accuracy will be a random num of meters between 0 and this value.
+                    Aggressiveness = 1f, // controls how responsive tracking is.
+                    MaxLateralThrust = 0.5, // controls how sharp the trajectile may turn
+                    TrackingDelay = 0, // Measured in Shape diameter units traveled.
+                    MaxChaseTime = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    OverideTarget = true, // when set to true ammo picks its own target, does not use hardpoint's.
+                    MaxTargets = 0, // Number of targets allowed before ending, 0 = unlimited
+                    NoTargetExpire = false, // Expire without ever having a target at TargetLossTime
+                    Roam = false, // Roam current area after target loss
+                    KeepAliveAfterTargetLoss = false, // Whether to stop early death of projectile on target loss
+                },
+                Mines = new MinesDef
+                {
+                    DetectRadius = 0,
+                    DeCloakRadius = 0,
+                    FieldTime = 0,
+                    Cloak = false,
+                    Persist = false,
+                },
+            },
+            AmmoGraphics = new GraphicDef
+            {
+                ModelName = "",
+                VisualProbability = 1f,
+                ShieldHitDraw = false,
+                Particles = new AmmoParticleDef
+                {
+                    Ammo = new ParticleDef
+                    {
+                        Name = "", //ShipWelderArc
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 128, green: 0, blue: 0, alpha: 32),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 0,
+                            Scale = 1,
+                        },
+                    },
+                    Hit = new ParticleDef
+                    {
+                        Name = "",
+                        ApplyToShield = true,
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 3, green: 1.9f, blue: 1f, alpha: 1),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 0,
+                            Scale = 1,
+                            HitPlayChance = 1f,
+                        },
+                    },
+                    Eject = new ParticleDef
+                    {
+                        Name = "MaterialHit_Metal_GatlingGun",
+                        ApplyToShield = true,
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 3, green: 1.9f, blue: 1f, alpha: 1),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 30,
+                            Scale = 1,
+                            HitPlayChance = 1f,
+                        },
+                    },
+                },
+                Lines = new LineDef
+                {
+                    ColorVariance = Random(start: 0.75f, end: 2f), // multiply the color by random values within range.
+                    WidthVariance = Random(start: 0f, end: 0f), // adds random value to default width (negatives shrinks width)
+                    Tracer = new TracerBaseDef
+                    {
+                        Enable = true,
+                        Length = 25f,
+                        Width = 4f,
                         Color = Color(red: 10, green: 25, blue: 50, alpha: 1),
                         VisualFadeStart = 0, // Number of ticks the weapon has been firing before projectiles begin to fade their color
                         VisualFadeEnd = 0, // How many ticks after fade began before it will be invisible.

--- a/Data/Scripts/CoreParts/AryxEnergyCannonMagnetar_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxEnergyCannonMagnetar_Weapon.cs
@@ -23,7 +23,7 @@ namespace Scripts {
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 2.0f,
+                        DurabilityMod = 0.667f,
                         IconName = "AryxMagnetarCannon.dds"
                     },
                    
@@ -181,7 +181,8 @@ namespace Scripts {
                 },
             },
             Ammos = new[] {
-                AryxMagnetarAmmo, // must list primary, shrapnel and pattern ammos
+                AryxMagnetarAmmo,
+                AryxMagnetarBusterAmmo, // must list primary, shrapnel and pattern ammos
             },
             //Animations = Weapon75_Animation,
             //Upgrades = UpgradeModules,

--- a/Data/Scripts/CoreParts/AryxEnergyCannonPulsar_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxEnergyCannonPulsar_AmmoTypes.cs
@@ -401,5 +401,380 @@ namespace Scripts
             },
         };
 
+        private AmmoDef AryxPulsarBusterAmmo => new AmmoDef
+        {
+            AmmoMagazine = "Energy", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo
+            AmmoRound = "Pulsar Bunker Buster Energy Bolt", // name of ammo in terminal, should be unique for each ammo type. Used for Name field in server config
+            HybridRound = false, //AmmoMagazine based weapon with energy cost
+            EnergyCost = 1, //(((EnergyCost * DefaultDamage) * ShotsPerSecond) * BarrelsPerShot) * ShotsPerBarrel
+            BaseDamage = (float)(1 * AWEGlobalDamageScalar),
+            Mass = 0f, // in kilograms
+            Health = 0, // 0 = disabled, otherwise how much damage it can take from other trajectiles before dying.
+            BackKickForce = 0f,
+            DecayPerShot = 0f,
+            HardPointUsable = true, // set to false if this is a shrapnel ammoType and you don't want the turret to be able to select it directly.
+            EnergyMagazineSize = 1,
+            IgnoreWater = false,
+
+            Shape = new ShapeDef //defines the collision shape of projectile, defaults line and visual Line Length if set to 0
+            {
+                Shape = LineShape, // LineShape or SphereShape. Do not use SphereShape for fast moving projectiles if you care about precision.
+                Diameter = 1, // Diameter is minimum length of LineShape or minimum diameter of SphereShape
+            },
+            ObjectsHit = new ObjectsHitDef
+            {
+                MaxObjectsHit = 1, // 0 = disabled
+                CountBlocks = true, // counts gridBlocks and not just entities hit
+            },
+            Fragment = new FragmentDef
+            {
+                AmmoRound = "",
+                Fragments = 100,
+                Degrees = 15,
+                Reverse = false,
+                
+            },
+            Pattern = new PatternDef
+            {
+                Patterns = new[] {
+                    "",
+                },
+                Enable = false,
+                TriggerChance = 1f,
+                Random = false,
+                RandomMin = 1,
+                RandomMax = 1,
+                SkipParent = false,
+                PatternSteps = 1, // Number of Ammos activated per round, will progress in order and loop.  Ignored if Random = true.
+            },
+            DamageScales = new DamageScaleDef
+            {
+                MaxIntegrity = 0f, // 0 = disabled, 1000 = any blocks with currently integrity above 1000 will be immune to damage.
+                DamageVoxels = false, // true = voxels are vulnerable to this weapon
+                SelfDamage = false, // true = allow self damage.
+                HealthHitModifier = 0.5, // defaults to a value of 1, this setting modifies how much Health is subtracted from a projectile per hit (1 = per hit).
+                VoxelHitModifier = 1,
+                Characters = -1f,
+                // modifier values: -1 = disabled (higher performance), 0 = no damage, 0.01 = 1% damage, 2 = 200% damage.
+                FallOff = new FallOffDef
+                {
+                    Distance = 5000f, // Distance at which max damage begins falling off.
+                    MinMultipler = 1f, // value from 0.0001f to 1f where 0.1f would be a min damage of 10% of max damage.
+                },
+                Grids = new GridSizeDef
+                {
+                    Large = -1f,
+                    Small = 0.2f,
+                },
+                Armor = new ArmorDef
+                {
+                    Armor = 0.0001f,
+                    Light = -1f,
+                    Heavy = -1f,
+                    NonArmor = 0.0001f,
+                },
+                Shields = new ShieldDef
+                {
+                    Modifier = 100f,
+                    Type = Default, // Default, Heal
+                    BypassModifier = -2f,
+                },
+                DamageType = new DamageTypes
+                {
+                    Base = Energy,
+                    AreaEffect = Energy,
+                    Detonation = Energy,
+                    Shield = Energy,
+                },
+                // first true/false (ignoreOthers) will cause projectiles to pass through all blocks that do not match the custom subtypeIds.
+                Custom = new CustomScalesDef
+                {
+                    IgnoreAllOthers = false,
+                    Types = new[]
+                    {
+                        new CustomBlocksDef
+                        {
+                            SubTypeId = "Test1",
+                            Modifier = -1f,
+                        },
+                        new CustomBlocksDef
+                        {
+                            SubTypeId = "Test2",
+                            Modifier = -1f,
+                        },
+                    },
+                },
+            },
+			AreaOfDamage = new AreaOfDamageDef
+            {
+                ByBlockHit = new ByBlockHitDef
+                {
+                    Enable = false,
+                    Radius = 2.5f, // Meters
+                    Damage = (float)(1700 * AWEGlobalDamageScalar),
+                    Depth = 1.5f, // Meters
+                    MaxAbsorb = 0f,
+                    Falloff = Linear, //.NoFalloff applies the same damage to all blocks in radius
+                    //.Linear drops evenly by distance from center out to max radius
+                    //.Curve drops off damage sharply as it approaches the max radius
+                    //.InvCurve drops off sharply from the middle and tapers to max radius
+                    //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
+                    //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
+                    Shape = Diamond, // Round or Diamond
+                },
+                EndOfLife = new EndOfLifeDef
+                {
+                    Enable = true,
+                    Radius = 3f, // Meters
+                    Damage = (float)(3100 * AWEGlobalDamageScalar),
+                    Depth = 1.5f,
+                    MaxAbsorb = 0f,
+                    Falloff = Linear, //.NoFalloff applies the same damage to all blocks in radius
+                    //.Linear drops evenly by distance from center out to max radius
+                    //.Curve drops off damage sharply as it approaches the max radius
+                    //.InvCurve drops off sharply from the middle and tapers to max radius
+                    //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
+                    //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
+                    ArmOnlyOnHit = false, // Detonation only is available, After it hits something, when this is true. IE, if shot down, it won't explode.
+                    MinArmingTime = 120, // In ticks, before the Ammo is allowed to explode, detonate or similar; This affects shrapnel spawning.
+                    NoVisuals = false,
+                    NoSound = false,
+                    ParticleScale = 1,
+                    CustomParticle = "AWE_Shockcannon_Explosion", // Particle SubtypeID, from your Particle SBC
+                    CustomSound = "ArcWepShipARYX_ShockCannonHit", // SubtypeID from your Audio SBC, not a filename
+                    Shape = Diamond, // Round or Diamond
+                }, 
+            },
+            Ewar = new EwarDef
+            {
+                Enable = false, // Enables EWAR effects AND DISABLES BASE DAMAGE AND AOE DAMAGE!!
+                Type = EnergySink, // EnergySink, Emp, Offense, Nav, Dot, AntiSmart, JumpNull, Anchor, Tractor, Pull, Push, 
+                Mode = Effect, // Effect , Field
+                Strength = 100f,
+                Radius = 5f, // Meters
+                Duration = 100, // In Ticks
+                StackDuration = true, // Combined Durations
+                Depletable = true,
+                MaxStacks = 10, // Max Debuffs at once
+                NoHitParticle = false,
+                /*
+                EnergySink : Targets & Shutdowns Power Supplies, such as Batteries & Reactor
+                Emp : Targets & Shutdown any Block capable of being powered
+                Offense : Targets & Shutdowns Weaponry
+                Nav : Targets & Shutdown Gyros, Thrusters, or Locks them down
+                Dot : Deals Damage to Blocks in radius
+                AntiSmart : Effects & Scrambles the Targeting List of Affected Missiles
+                JumpNull : Shutdown & Stops any Active Jumps, or JumpDrive Units in radius
+                Tractor : Affects target with Physics
+                Pull : Affects target with Physics
+                Push : Affects target with Physics
+                Anchor : Affects target with Physics
+                
+                */
+                Force = new PushPullDef
+                {
+                    ForceFrom = ProjectileLastPosition, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    ForceTo = HitPosition, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    Position = TargetCenterOfMass, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    DisableRelativeMass = false,
+                    TractorRange = 0,
+                    ShooterFeelsForce = false,
+                },
+                Field = new FieldDef
+                {
+                    Interval = 0, // Time between each pulse, in game ticks (60 == 1 second).
+                    PulseChance = 0, // Chance from 0 - 100 that an entity in the field will be hit by any given pulse.
+                    GrowTime = 0, // How many ticks it should take the field to grow to full size.
+                    HideModel = false, // Hide the projectile model if it has one.
+                    ShowParticle = true, // Show Block damage effect.
+                    TriggerRange = 250f, //range at which fields are triggered
+                    Particle = new ParticleDef // Particle effect to generate at the field's position.
+                    {
+                        Name = "", // SubtypeId of field particle effect.
+                        Extras = new ParticleOptionDef
+                        {
+                            Scale = 1, // Scale of effect.
+                        },
+                    },
+                },
+            },
+            Beams = new BeamDef
+            {
+                Enable = false,
+                VirtualBeams = false, // Only one hot beam, but with the effectiveness of the virtual beams combined (better performace)
+                ConvergeBeams = false, // When using virtual beams this option visually converges the beams to the location of the real beam.
+                RotateRealBeam = false, // The real (hot beam) is rotated between all virtual beams, instead of centered between them.
+                OneParticle = false, // Only spawn one particle hit per beam weapon.
+            },
+            Trajectory = new TrajectoryDef
+            {
+                Guidance = None,
+                TargetLossDegree = 80f,
+                TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                AccelPerSec = 0f,
+                DesiredSpeed = 600, // voxel phasing if you go above 5100
+                MaxTrajectory = 10000,
+                //FieldTime was here, it's dead now is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
+                GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
+                SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed
+                RangeVariance = Random(start: 0, end: 0), // subtracts value from MaxTrajectory
+                MaxTrajectoryTime = 0, // How long the weapon must fire before it reaches MaxTrajectory.
+                Smarts = new SmartsDef
+                {
+                    Inaccuracy = 0f, // 0 is perfect, hit accuracy will be a random num of meters between 0 and this value.
+                    Aggressiveness = 1f, // controls how responsive tracking is.
+                    MaxLateralThrust = 0.5, // controls how sharp the trajectile may turn
+                    TrackingDelay = 0, // Measured in Shape diameter units traveled.
+                    MaxChaseTime = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    OverideTarget = true, // when set to true ammo picks its own target, does not use hardpoint's.
+                    MaxTargets = 0, // Number of targets allowed before ending, 0 = unlimited
+                    NoTargetExpire = false, // Expire without ever having a target at TargetLossTime
+                    Roam = false, // Roam current area after target loss
+                    KeepAliveAfterTargetLoss = false, // Whether to stop early death of projectile on target loss
+                },
+                Mines = new MinesDef
+                {
+                    DetectRadius = 0,
+                    DeCloakRadius = 0,
+                    FieldTime = 0,
+                    Cloak = false,
+                    Persist = false,
+                },
+            },
+            AmmoGraphics = new GraphicDef
+            {
+                ModelName = "",
+                VisualProbability = 1f,
+                ShieldHitDraw = false,
+                Particles = new AmmoParticleDef
+                {
+                    Ammo = new ParticleDef
+                    {
+                        Name = "", //ShipWelderArc
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 128, green: 0, blue: 0, alpha: 32),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 0,
+                            Scale = 1,
+                        },
+                    },
+                    Hit = new ParticleDef
+                    {
+                        Name = "",
+                        ApplyToShield = true,
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 3, green: 1.9f, blue: 1f, alpha: 1),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 0,
+                            Scale = 1,
+                            HitPlayChance = 1f,
+                        },
+                    },
+                    Eject = new ParticleDef
+                    {
+                        Name = "MaterialHit_Metal_GatlingGun",
+                        ApplyToShield = true,
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 3, green: 1.9f, blue: 1f, alpha: 1),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 30,
+                            Scale = 1,
+                            HitPlayChance = 1f,
+                        },
+                    },
+                },
+                Lines = new LineDef
+                {
+                    ColorVariance = Random(start: 0.75f, end: 2f), // multiply the color by random values within range.
+                    WidthVariance = Random(start: 0f, end: 0f), // adds random value to default width (negatives shrinks width)
+                    Tracer = new TracerBaseDef
+                    {
+                        Enable = true,
+                        Length = 25f,
+                        Width = 4f,
+                        Color = Color(red: 10, green: 25, blue: 50, alpha: 1),
+                        VisualFadeStart = 0, // Number of ticks the weapon has been firing before projectiles begin to fade their color
+                        VisualFadeEnd = 0, // How many ticks after fade began before it will be invisible.
+                        Textures = new[] {// WeaponLaser, ProjectileTrailLine, WarpBubble, etc..
+                            "AryxBallisticTracer",
+                        },
+                        TextureMode = Normal, // Normal, Cycle, Chaos, Wave
+                        Segmentation = new SegmentDef
+                        {
+                            Enable = false, // If true Tracer TextureMode is ignored
+                            Textures = new[] {
+                                "",
+                            },
+                            SegmentLength = 0f, // Uses the values below.
+                            SegmentGap = 0f, // Uses Tracer textures and values
+                            Speed = 1f, // meters per second
+                            Color = Color(red: 1, green: 2, blue: 2.5f, alpha: 1),
+                            WidthMultiplier = 1f,
+                            Reverse = false,
+                            UseLineVariance = true,
+                            WidthVariance = Random(start: 0f, end: 0f),
+                            ColorVariance = Random(start: 0f, end: 0f)
+                        }
+                    },
+                    Trail = new TrailDef
+                    {
+                        Enable = true,
+                        Textures = new[] {
+                            "WeaponLaser",
+                        },
+                        TextureMode = Normal,
+                        DecayTime = 60,
+                        Color = Color(red: 0, green: 0, blue: 1, alpha: 1),
+                        Back = false,
+                        CustomWidth = 0.15f,
+                        UseWidthVariance = false,
+                        UseColorFade = true,
+                    },
+                    OffsetEffect = new OffsetEffectDef
+                    {
+                        MaxOffset = 0,// 0 offset value disables this effect
+                        MinLength = 0.2f,
+                        MaxLength = 3,
+                    },
+                },
+            },
+            AmmoAudio = new AmmoAudioDef
+            {
+                TravelSound = "",
+                HitSound = "",
+                ShieldHitSound = "",
+                PlayerHitSound = "",
+                VoxelHitSound = "",
+                FloatingHitSound = "",
+                HitPlayChance = 0.5f,
+                HitPlayShield = true,
+            }, // Don't edit below this line
+            Ejection = new EjectionDef
+            {
+                Type = Particle, // Particle or Item (Inventory Component)
+                Speed = 100f, // Speed inventory is ejected from in dummy direction
+                SpawnChance = 0.5f, // chance of triggering effect (0 - 1)
+                CompDef = new ComponentDef
+                {
+                    ItemName = "", //InventoryComponent name
+                    ItemLifeTime = 0, // how long item should exist in world
+                    Delay = 0, // delay in ticks after shot before ejected
+                }
+            },
+        };
+
      }
 }

--- a/Data/Scripts/CoreParts/AryxEnergyCannonPulsar_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxEnergyCannonPulsar_Weapon.cs
@@ -23,7 +23,7 @@ namespace Scripts {
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 0.25f,
+                        DurabilityMod = 0.125f,
                         IconName = "AryxMagnetarCannon.dds"
                     },
                    
@@ -178,7 +178,8 @@ namespace Scripts {
                 },
             },
             Ammos = new[] {
-                AryxPulsarAmmo, // must list primary, shrapnel and pattern ammos
+                AryxPulsarAmmo,
+                AryxPulsarBusterAmmo, // must list primary, shrapnel and pattern ammos
             },
             //Animations = Weapon75_Animation,
             //Upgrades = UpgradeModules,

--- a/Data/Scripts/CoreParts/AryxEnergyCannonQuasar_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxEnergyCannonQuasar_AmmoTypes.cs
@@ -401,5 +401,381 @@ namespace Scripts
             },
         };
 
+
+        private AmmoDef AryxQuasarBusterAmmo => new AmmoDef
+        {
+            AmmoMagazine = "Energy", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo
+            AmmoRound = "Quasar Bunker Buster Energy Bolt", // name of ammo in terminal, should be unique for each ammo type. Used for Name field in server config
+            HybridRound = false, //AmmoMagazine based weapon with energy cost
+            EnergyCost = 0.41991602f, //(((EnergyCost * DefaultDamage) * ShotsPerSecond) * BarrelsPerShot) * ShotsPerBarrel
+            BaseDamage = (float)(1 * AWEGlobalDamageScalar),
+            Mass = 0f, // in kilograms
+            Health = 0, // 0 = disabled, otherwise how much damage it can take from other trajectiles before dying.
+            BackKickForce = 0f,
+            DecayPerShot = 0f,
+            HardPointUsable = true, // set to false if this is a shrapnel ammoType and you don't want the turret to be able to select it directly.
+            EnergyMagazineSize = 2,
+            IgnoreWater = false,
+
+            Shape = new ShapeDef //defines the collision shape of projectile, defaults line and visual Line Length if set to 0
+            {
+                Shape = LineShape, // LineShape or SphereShape. Do not use SphereShape for fast moving projectiles if you care about precision.
+                Diameter = 1, // Diameter is minimum length of LineShape or minimum diameter of SphereShape
+            },
+            ObjectsHit = new ObjectsHitDef
+            {
+                MaxObjectsHit = 1, // 0 = disabled
+                CountBlocks = true, // counts gridBlocks and not just entities hit
+            },
+            Fragment = new FragmentDef
+            {
+                AmmoRound = "",
+                Fragments = 100,
+                Degrees = 15,
+                Reverse = false,
+                
+            },
+            Pattern = new PatternDef
+            {
+                Patterns = new[] {
+                    "",
+                },
+                Enable = false,
+                TriggerChance = 1f,
+                Random = false,
+                RandomMin = 1,
+                RandomMax = 1,
+                SkipParent = false,
+                PatternSteps = 1, // Number of Ammos activated per round, will progress in order and loop.  Ignored if Random = true.
+            },
+            DamageScales = new DamageScaleDef
+            {
+                MaxIntegrity = 0f, // 0 = disabled, 1000 = any blocks with currently integrity above 1000 will be immune to damage.
+                DamageVoxels = false, // true = voxels are vulnerable to this weapon
+                SelfDamage = false, // true = allow self damage.
+                HealthHitModifier = 0.5, // defaults to a value of 1, this setting modifies how much Health is subtracted from a projectile per hit (1 = per hit).
+                VoxelHitModifier = 1,
+                Characters = -1f,
+                // modifier values: -1 = disabled (higher performance), 0 = no damage, 0.01 = 1% damage, 2 = 200% damage.
+                FallOff = new FallOffDef
+                {
+                    Distance = 5000f, // Distance at which max damage begins falling off.
+                    MinMultipler = 1f, // value from 0.0001f to 1f where 0.1f would be a min damage of 10% of max damage.
+                },
+                Grids = new GridSizeDef
+                {
+                    Large = -1f,
+                    Small = 0.2f,
+                },
+                Armor = new ArmorDef
+                {
+                    Armor = 0.0001f,
+                    Light = -1f,
+                    Heavy = -1f,
+                    NonArmor = 0.0001f,
+                },
+                Shields = new ShieldDef
+                {
+                    Modifier = 60f,
+                    Type = Default, // Default, Heal
+                    BypassModifier = -2f,
+                },
+                DamageType = new DamageTypes
+                {
+                    Base = Energy,
+                    AreaEffect = Energy,
+                    Detonation = Energy,
+                    Shield = Energy,
+                },
+                // first true/false (ignoreOthers) will cause projectiles to pass through all blocks that do not match the custom subtypeIds.
+                Custom = new CustomScalesDef
+                {
+                    IgnoreAllOthers = false,
+                    Types = new[]
+                    {
+                        new CustomBlocksDef
+                        {
+                            SubTypeId = "Test1",
+                            Modifier = -1f,
+                        },
+                        new CustomBlocksDef
+                        {
+                            SubTypeId = "Test2",
+                            Modifier = -1f,
+                        },
+                    },
+                },
+            },
+			AreaOfDamage = new AreaOfDamageDef
+            {
+                ByBlockHit = new ByBlockHitDef
+                {
+                    Enable = false,
+                    Radius = 3.5f, // Meters
+                    Damage = (float)(5500 * AWEGlobalDamageScalar),
+                    Depth = 2.6f, // Meters
+                    MaxAbsorb = 0f,
+                    Falloff = Linear, //.NoFalloff applies the same damage to all blocks in radius
+                    //.Linear drops evenly by distance from center out to max radius
+                    //.Curve drops off damage sharply as it approaches the max radius
+                    //.InvCurve drops off sharply from the middle and tapers to max radius
+                    //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
+                    //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
+                    Shape = Diamond, // Round or Diamond
+                },
+                EndOfLife = new EndOfLifeDef
+                {
+                    Enable = true,
+                    Radius = 5.2f, // Meters
+                    Damage = (float)(8000 * AWEGlobalDamageScalar),
+                    Depth = 3.2f,
+                    MaxAbsorb = 0f,
+                    Falloff = Linear, //.NoFalloff applies the same damage to all blocks in radius
+                    //.Linear drops evenly by distance from center out to max radius
+                    //.Curve drops off damage sharply as it approaches the max radius
+                    //.InvCurve drops off sharply from the middle and tapers to max radius
+                    //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
+                    //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
+                    ArmOnlyOnHit = false, // Detonation only is available, After it hits something, when this is true. IE, if shot down, it won't explode.
+                    MinArmingTime = 120, // In ticks, before the Ammo is allowed to explode, detonate or similar; This affects shrapnel spawning.
+                    NoVisuals = false,
+                    NoSound = false,
+                    ParticleScale = 1,
+                    CustomParticle = "AWE_Shockcannon_Explosion", // Particle SubtypeID, from your Particle SBC
+                    CustomSound = "ArcWepShipARYX_ShockCannonHit", // SubtypeID from your Audio SBC, not a filename
+                    Shape = Diamond, // Round or Diamond
+                }, 
+            },
+            Ewar = new EwarDef
+            {
+                Enable = false, // Enables EWAR effects AND DISABLES BASE DAMAGE AND AOE DAMAGE!!
+                Type = EnergySink, // EnergySink, Emp, Offense, Nav, Dot, AntiSmart, JumpNull, Anchor, Tractor, Pull, Push, 
+                Mode = Effect, // Effect , Field
+                Strength = 100f,
+                Radius = 5f, // Meters
+                Duration = 100, // In Ticks
+                StackDuration = true, // Combined Durations
+                Depletable = true,
+                MaxStacks = 10, // Max Debuffs at once
+                NoHitParticle = false,
+                /*
+                EnergySink : Targets & Shutdowns Power Supplies, such as Batteries & Reactor
+                Emp : Targets & Shutdown any Block capable of being powered
+                Offense : Targets & Shutdowns Weaponry
+                Nav : Targets & Shutdown Gyros, Thrusters, or Locks them down
+                Dot : Deals Damage to Blocks in radius
+                AntiSmart : Effects & Scrambles the Targeting List of Affected Missiles
+                JumpNull : Shutdown & Stops any Active Jumps, or JumpDrive Units in radius
+                Tractor : Affects target with Physics
+                Pull : Affects target with Physics
+                Push : Affects target with Physics
+                Anchor : Affects target with Physics
+                
+                */
+                Force = new PushPullDef
+                {
+                    ForceFrom = ProjectileLastPosition, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    ForceTo = HitPosition, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    Position = TargetCenterOfMass, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    DisableRelativeMass = false,
+                    TractorRange = 0,
+                    ShooterFeelsForce = false,
+                },
+                Field = new FieldDef
+                {
+                    Interval = 0, // Time between each pulse, in game ticks (60 == 1 second).
+                    PulseChance = 0, // Chance from 0 - 100 that an entity in the field will be hit by any given pulse.
+                    GrowTime = 0, // How many ticks it should take the field to grow to full size.
+                    HideModel = false, // Hide the projectile model if it has one.
+                    ShowParticle = true, // Show Block damage effect.
+                    TriggerRange = 250f, //range at which fields are triggered
+                    Particle = new ParticleDef // Particle effect to generate at the field's position.
+                    {
+                        Name = "", // SubtypeId of field particle effect.
+                        Extras = new ParticleOptionDef
+                        {
+                            Scale = 1, // Scale of effect.
+                        },
+                    },
+                },
+            },
+            Beams = new BeamDef
+            {
+                Enable = false,
+                VirtualBeams = false, // Only one hot beam, but with the effectiveness of the virtual beams combined (better performace)
+                ConvergeBeams = false, // When using virtual beams this option visually converges the beams to the location of the real beam.
+                RotateRealBeam = false, // The real (hot beam) is rotated between all virtual beams, instead of centered between them.
+                OneParticle = false, // Only spawn one particle hit per beam weapon.
+            },
+            Trajectory = new TrajectoryDef
+            {
+                Guidance = None,
+                TargetLossDegree = 80f,
+                TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                AccelPerSec = 0f,
+                DesiredSpeed = 800, // voxel phasing if you go above 5100
+                MaxTrajectory = 10000,
+                //FieldTime was here, it's dead now is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
+                GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
+                SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed
+                RangeVariance = Random(start: 0, end: 0), // subtracts value from MaxTrajectory
+                MaxTrajectoryTime = 0, // How long the weapon must fire before it reaches MaxTrajectory.
+                Smarts = new SmartsDef
+                {
+                    Inaccuracy = 0f, // 0 is perfect, hit accuracy will be a random num of meters between 0 and this value.
+                    Aggressiveness = 1f, // controls how responsive tracking is.
+                    MaxLateralThrust = 0.5, // controls how sharp the trajectile may turn
+                    TrackingDelay = 0, // Measured in Shape diameter units traveled.
+                    MaxChaseTime = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    OverideTarget = true, // when set to true ammo picks its own target, does not use hardpoint's.
+                    MaxTargets = 0, // Number of targets allowed before ending, 0 = unlimited
+                    NoTargetExpire = false, // Expire without ever having a target at TargetLossTime
+                    Roam = false, // Roam current area after target loss
+                    KeepAliveAfterTargetLoss = false, // Whether to stop early death of projectile on target loss
+                },
+                Mines = new MinesDef
+                {
+                    DetectRadius = 0,
+                    DeCloakRadius = 0,
+                    FieldTime = 0,
+                    Cloak = false,
+                    Persist = false,
+                },
+            },
+            AmmoGraphics = new GraphicDef
+            {
+                ModelName = "",
+                VisualProbability = 1f,
+                ShieldHitDraw = false,
+                Particles = new AmmoParticleDef
+                {
+                    Ammo = new ParticleDef
+                    {
+                        Name = "", //ShipWelderArc
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 128, green: 0, blue: 0, alpha: 32),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 0,
+                            Scale = 1,
+                        },
+                    },
+                    Hit = new ParticleDef
+                    {
+                        Name = "",
+                        ApplyToShield = true,
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 3, green: 1.9f, blue: 1f, alpha: 1),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 0,
+                            Scale = 1,
+                            HitPlayChance = 1f,
+                        },
+                    },
+                    Eject = new ParticleDef
+                    {
+                        Name = "MaterialHit_Metal_GatlingGun",
+                        ApplyToShield = true,
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 3, green: 1.9f, blue: 1f, alpha: 1),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 30,
+                            Scale = 1,
+                            HitPlayChance = 1f,
+                        },
+                    },
+                },
+                Lines = new LineDef
+                {
+                    ColorVariance = Random(start: 0.75f, end: 2f), // multiply the color by random values within range.
+                    WidthVariance = Random(start: 0f, end: 0f), // adds random value to default width (negatives shrinks width)
+                    Tracer = new TracerBaseDef
+                    {
+                        Enable = true,
+                        Length = 25f,
+                        Width = 4f,
+                        Color = Color(red: 10, green: 25, blue: 50, alpha: 1),
+                        VisualFadeStart = 0, // Number of ticks the weapon has been firing before projectiles begin to fade their color
+                        VisualFadeEnd = 0, // How many ticks after fade began before it will be invisible.
+                        Textures = new[] {// WeaponLaser, ProjectileTrailLine, WarpBubble, etc..
+                            "AryxBallisticTracer",
+                        },
+                        TextureMode = Normal, // Normal, Cycle, Chaos, Wave
+                        Segmentation = new SegmentDef
+                        {
+                            Enable = false, // If true Tracer TextureMode is ignored
+                            Textures = new[] {
+                                "",
+                            },
+                            SegmentLength = 0f, // Uses the values below.
+                            SegmentGap = 0f, // Uses Tracer textures and values
+                            Speed = 1f, // meters per second
+                            Color = Color(red: 1, green: 2, blue: 2.5f, alpha: 1),
+                            WidthMultiplier = 1f,
+                            Reverse = false,
+                            UseLineVariance = true,
+                            WidthVariance = Random(start: 0f, end: 0f),
+                            ColorVariance = Random(start: 0f, end: 0f)
+                        }
+                    },
+                    Trail = new TrailDef
+                    {
+                        Enable = true,
+                        Textures = new[] {
+                            "WeaponLaser",
+                        },
+                        TextureMode = Normal,
+                        DecayTime = 60,
+                        Color = Color(red: 0, green: 0, blue: 1, alpha: 1),
+                        Back = false,
+                        CustomWidth = 0.15f,
+                        UseWidthVariance = false,
+                        UseColorFade = true,
+                    },
+                    OffsetEffect = new OffsetEffectDef
+                    {
+                        MaxOffset = 0,// 0 offset value disables this effect
+                        MinLength = 0.2f,
+                        MaxLength = 3,
+                    },
+                },
+            },
+            AmmoAudio = new AmmoAudioDef
+            {
+                TravelSound = "",
+                HitSound = "",
+                ShieldHitSound = "",
+                PlayerHitSound = "",
+                VoxelHitSound = "",
+                FloatingHitSound = "",
+                HitPlayChance = 0.5f,
+                HitPlayShield = true,
+            }, // Don't edit below this line
+            Ejection = new EjectionDef
+            {
+                Type = Particle, // Particle or Item (Inventory Component)
+                Speed = 100f, // Speed inventory is ejected from in dummy direction
+                SpawnChance = 0.5f, // chance of triggering effect (0 - 1)
+                CompDef = new ComponentDef
+                {
+                    ItemName = "", //InventoryComponent name
+                    ItemLifeTime = 0, // how long item should exist in world
+                    Delay = 0, // delay in ticks after shot before ejected
+                }
+            },
+        };
+
      }
 }

--- a/Data/Scripts/CoreParts/AryxEnergyCannonQuasar_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxEnergyCannonQuasar_Weapon.cs
@@ -180,7 +180,8 @@ namespace Scripts {
                 },
             },
             Ammos = new[] {
-                AryxQuasarAmmo, // must list primary, shrapnel and pattern ammos
+                AryxQuasarAmmo,
+                AryxQuasarBusterAmmo, // must list primary, shrapnel and pattern ammos
             },
             //Animations = Weapon75_Animation,
             //Upgrades = UpgradeModules,

--- a/Data/Scripts/CoreParts/AryxFlakHeavy_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxFlakHeavy_Weapon.cs
@@ -25,7 +25,7 @@ namespace Scripts
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 0.2f,
+                        DurabilityMod = 0.1f,
                     },
 
                 },

--- a/Data/Scripts/CoreParts/AryxFlakLight_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxFlakLight_Weapon.cs
@@ -25,7 +25,7 @@ namespace Scripts
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 0.10f,
+                        DurabilityMod = 0.05f,
                     },
 
                 },

--- a/Data/Scripts/CoreParts/AryxFocusBeamLance_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxFocusBeamLance_Weapon.cs
@@ -24,7 +24,7 @@ namespace Scripts
                         MuzzlePartId = "None",
                         AzimuthPartId = "None",
                         ElevationPartId = "None",
-                        DurabilityMod = 0.25f,
+                        DurabilityMod = 0.125f,
                     },
 
                 },

--- a/Data/Scripts/CoreParts/AryxGatlingVulcan_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxGatlingVulcan_AmmoTypes.cs
@@ -409,5 +409,388 @@ namespace Scripts
             },
         };
 
+        private AmmoDef AryxVulcanBusterAmmoWC => new AmmoDef
+        {
+            AmmoMagazine = "ATLASAmmoMagazine",
+            AmmoRound = "MG61T Vulcan Buster Ammo",
+            HybridRound = false, //AmmoMagazine based weapon with energy cost
+            EnergyCost = 0.00000000000f, //(((EnergyCost * DefaultDamage) * ShotsPerSecond) * BarrelsPerShot) * ShotsPerBarrel
+            BaseDamage = (float)(1 * AWEGlobalDamageScalar),
+            Mass = 1, // in kilograms
+            Health = 0, // 0 = disabled, otherwise how much damage it can take from other trajectiles before dying.
+            BackKickForce = 600,
+            DecayPerShot = 0,
+            HardPointUsable = true, // set to false if this is a shrapnel ammoType and you don't want the turret to be able to select it directly.
+            IgnoreWater = true,
+
+            Shape = new ShapeDef //defines the collision shape of projectile, defaults line and visual Line Length if set to 0
+            {
+                Shape = LineShape,
+                Diameter = 2,
+            },
+            ObjectsHit = new ObjectsHitDef
+            {
+                MaxObjectsHit = 0, // 0 = disabled
+                CountBlocks = false, // counts gridBlocks and not just entities hit
+            },
+            Fragment = new FragmentDef
+            {
+                AmmoRound = "",
+                Fragments = 100,
+                Degrees = 15,
+                Reverse = false,
+                
+            },
+            Pattern = new PatternDef
+            {
+                Patterns = new[] {
+                    "",
+                },
+                Enable = false,
+                TriggerChance = 1f,
+                Random = false,
+                RandomMin = 1,
+                RandomMax = 1,
+                SkipParent = false,
+				PatternSteps = 1,
+            },
+            DamageScales = new DamageScaleDef
+            {
+                MaxIntegrity = 0f, // 0 = disabled, 1000 = any blocks with currently integrity above 1000 will be immune to damage.
+                DamageVoxels = false, // true = voxels are vulnerable to this weapon
+                SelfDamage = false, // true = allow self damage.
+                HealthHitModifier = 12, // defaults to a value of 1, this setting modifies how much Health is subtracted from a projectile per hit (1 = per hit).
+                VoxelHitModifier = 1,
+                Characters = 90f,
+                FallOff = new FallOffDef
+                {
+                    Distance = 1000f, // Distance at which max damage begins falling off.
+                    MinMultipler = 1f, // value from 0.0f to 1f where 0.1f would be a min damage of 10% of max damage.
+                },
+                Grids = new GridSizeDef
+                {
+                    Large = -1f,
+                    Small = -1f,
+                },
+                Armor = new ArmorDef
+                {
+                    Armor = 0.0001f,
+                    Light = -1f,
+                    Heavy = -1f,
+                    NonArmor = 0.0001f,
+                },
+                Shields = new ShieldDef
+                {
+                    Modifier = 50f,
+                    Type = Default,
+                    BypassModifier = -2f,
+                },
+                DamageType = new DamageTypes
+                {
+                    Base = Kinetic,
+                    AreaEffect = Kinetic,
+                    Detonation = Kinetic,
+                    Shield = Kinetic,
+                },				
+                // first true/false (ignoreOthers) will cause projectiles to pass through all blocks that do not match the custom subtypeIds.
+                Custom = new CustomScalesDef
+                {
+                    IgnoreAllOthers = false,
+                    Types = new[]
+                    {
+                        new CustomBlocksDef
+                        {
+                            SubTypeId = "Test1",
+                            Modifier = -1f,
+                        },
+                        new CustomBlocksDef
+                        {
+                            SubTypeId = "Test2",
+                            Modifier = -1f,
+                        },
+                    },
+                },
+            },
+            AreaOfDamage = new AreaOfDamageDef
+            {
+                ByBlockHit = new ByBlockHitDef
+                {
+                    Enable = false,
+                    Radius = 0f, // Meters
+                    Damage = 0f,
+                    Depth = 1f, // Meters
+                    MaxAbsorb = 0f,
+                    Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius
+                    //.Linear drops evenly by distance from center out to max radius
+                    //.Curve drops off damage sharply as it approaches the max radius
+                    //.InvCurve drops off sharply from the middle and tapers to max radius
+                    //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
+                    //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
+                    Shape = Diamond, // Round or Diamond
+                },
+                EndOfLife = new EndOfLifeDef
+                {
+                    Enable = true,
+                    Radius = 1f, // Meters
+                    Damage = 80f,
+                    Depth = 1f,
+                    MaxAbsorb = 0f,
+                    Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius
+                    //.Linear drops evenly by distance from center out to max radius
+                    //.Curve drops off damage sharply as it approaches the max radius
+                    //.InvCurve drops off sharply from the middle and tapers to max radius
+                    //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
+                    //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
+                    ArmOnlyOnHit = false, // Detonation only is available, After it hits something, when this is true. IE, if shot down, it won't explode.
+                    MinArmingTime = 90, // In ticks, before the Ammo is allowed to explode, detonate or similar; This affects shrapnel spawning.
+                    NoVisuals = false,
+                    NoSound = false,
+                    ParticleScale = 1,
+                    CustomParticle = "particleName", // Particle SubtypeID, from your Particle SBC
+                    CustomSound = "soundName", // SubtypeID from your Audio SBC, not a filename
+                    Shape = Round, // Round or Diamond
+                }, 
+            },
+            Ewar = new EwarDef
+            {
+                Enable = false, // Enables EWAR effects AND DISABLES BASE DAMAGE AND AOE DAMAGE!!
+                Type = EnergySink, // EnergySink, Emp, Offense, Nav, Dot, AntiSmart, JumpNull, Anchor, Tractor, Pull, Push, 
+                Mode = Effect, // Effect , Field
+                Strength = 100f,
+                Radius = 5f, // Meters
+                Duration = 100, // In Ticks
+                StackDuration = true, // Combined Durations
+                Depletable = true,
+                MaxStacks = 10, // Max Debuffs at once
+                NoHitParticle = false,
+                /*
+                EnergySink : Targets & Shutdowns Power Supplies, such as Batteries & Reactor
+                Emp : Targets & Shutdown any Block capable of being powered
+                Offense : Targets & Shutdowns Weaponry
+                Nav : Targets & Shutdown Gyros, Thrusters, or Locks them down
+                Dot : Deals Damage to Blocks in radius
+                AntiSmart : Effects & Scrambles the Targeting List of Affected Missiles
+                JumpNull : Shutdown & Stops any Active Jumps, or JumpDrive Units in radius
+                Tractor : Affects target with Physics
+                Pull : Affects target with Physics
+                Push : Affects target with Physics
+                Anchor : Affects target with Physics
+                
+                */
+                Force = new PushPullDef
+                {
+                    ForceFrom = ProjectileLastPosition, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    ForceTo = HitPosition, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    Position = TargetCenterOfMass, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    DisableRelativeMass = false,
+                    TractorRange = 0,
+                    ShooterFeelsForce = false,
+                },
+                Field = new FieldDef
+                {
+                    Interval = 0, // Time between each pulse, in game ticks (60 == 1 second).
+                    PulseChance = 0, // Chance from 0 - 100 that an entity in the field will be hit by any given pulse.
+                    GrowTime = 0, // How many ticks it should take the field to grow to full size.
+                    HideModel = false, // Hide the projectile model if it has one.
+                    ShowParticle = true, // Show Block damage effect.
+                    TriggerRange = 250f, //range at which fields are triggered
+                    Particle = new ParticleDef // Particle effect to generate at the field's position.
+                    {
+                        Name = "", // SubtypeId of field particle effect.
+                        Extras = new ParticleOptionDef
+                        {
+                            Scale = 1, // Scale of effect.
+                        },
+                    },
+                },
+            },
+            Beams = new BeamDef
+            {
+                Enable = false,
+                VirtualBeams = false, // Only one hot beam, but with the effectiveness of the virtual beams combined (better performace)
+                ConvergeBeams = false, // When using virtual beams this option visually converges the beams to the location of the real beam.
+                RotateRealBeam = false, // The real (hot beam) is rotated between all virtual beams, instead of centered between them.
+                OneParticle = false, // Only spawn one particle hit per beam weapon.
+            },
+            Trajectory = new TrajectoryDef
+            {
+                Guidance = None,
+                TargetLossDegree = 80f,
+                TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                AccelPerSec = 0f,
+                DesiredSpeed = 400,
+                MaxTrajectory = 2000f,
+                //FieldTime was here, it's dead now is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
+                GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
+                SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed
+                RangeVariance = Random(start: 0, end: 0), // subtracts value from MaxTrajectory
+                MaxTrajectoryTime = 0, // How long the weapon must fire before it reaches MaxTrajectory.
+                Smarts = new SmartsDef
+                {
+                    Inaccuracy = 0f, // 0 is perfect, hit accuracy will be a random num of meters between 0 and this value.
+                    Aggressiveness = 1f, // controls how responsive tracking is.
+                    MaxLateralThrust = 0.5, // controls how sharp the trajectile may turn
+                    TrackingDelay = 0, // Measured in Shape diameter units traveled.
+                    MaxChaseTime = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    OverideTarget = true, // when set to true ammo picks its own target, does not use hardpoint's.
+                    MaxTargets = 0, // Number of targets allowed before ending, 0 = unlimited
+                    NoTargetExpire = false, // Expire without ever having a target at TargetLossTime
+                    Roam = false, // Roam current area after target loss
+                    KeepAliveAfterTargetLoss = false, // Whether to stop early death of projectile on target loss
+                },
+                Mines = new MinesDef
+                {
+                    DetectRadius = 0,
+                    DeCloakRadius = 0,
+                    FieldTime = 0,
+                    Cloak = false,
+                    Persist = false,
+                },
+            },
+            AmmoGraphics = new GraphicDef
+            {
+                ModelName = "",
+                VisualProbability = 1f,
+                ShieldHitDraw = true,
+                Particles = new AmmoParticleDef
+                {
+                    Ammo = new ParticleDef
+                    {
+                        Name = "", //ShipWelderArc
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 128, green: 0, blue: 0, alpha: 32),
+                        Offset = Vector(x: 0, y: -1, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Loop = false,
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 1,
+                            Scale = 1,
+                        },
+                    },
+                    Hit = new ParticleDef
+                    {
+                        Name = "AWE_LowCalHit",
+                        ApplyToShield = true,
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 3, green: 1.9f, blue: 1f, alpha: 1),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Loop = false,
+                            Restart = false,
+                            MaxDistance = 200,
+                            MaxDuration = 0,
+                            Scale = 1,
+                            HitPlayChance = 1f,
+                        },
+                    },
+                    Eject = new ParticleDef
+                    {
+                        Name = "",
+                        ApplyToShield = true,
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 3, green: 1.9f, blue: 1f, alpha: 1),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Loop = false,
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 30,
+                            Scale = 1,
+                            HitPlayChance = 1f,
+                        },
+                    },
+                },
+                Lines = new LineDef
+                {
+                    ColorVariance = Random(start: -0.75f, end: 2f), // multiply the color by random values within range.
+                    WidthVariance = Random(start: 0.3f, end: AWETracerVariation), // adds random value to default width (negatives shrinks width)
+                    Tracer = new TracerBaseDef
+                    {
+                        Enable = true,
+                        Length = 7f,
+                        Width = 0.004f,
+                        Color = Color(red: 25, green: 12, blue: 2, alpha: 1),
+                        VisualFadeStart = 0, // Number of ticks the weapon has been firing before projectiles begin to fade their color
+                        VisualFadeEnd = 0, // How many ticks after fade began before it will be invisible.
+                        Textures = new[] {// WeaponLaser, ProjectileTrailLine, WarpBubble, etc..
+                            "AryxBallisticTracer",
+                        },
+                        TextureMode = Normal, // Normal, Cycle, Chaos, Wave
+                        Segmentation = new SegmentDef
+                        {
+                            Enable = false, // If true Tracer TextureMode is ignored
+                            Textures = new[] {
+                                "BlackFireSeg1",
+                                "BlackFireSeg2",
+                                "BlackFireSeg3",
+                                "BlackFireSeg4",
+                                "BlackFireSeg5",
+                                "BlackFireSeg6",
+                                "BlackFireSeg7",
+                                "BlackFireSeg8",
+                            },
+                            SegmentLength = 30f, // Uses the values below.
+                            SegmentGap = 0f, // Uses Tracer textures and values
+                            Speed = 800f, // meters per second
+                            Color = Color(red: 2.5f, green: 2, blue: 1f, alpha: 1),
+                            WidthMultiplier = 1f,
+                            Reverse = false,
+                            UseLineVariance = true,
+                            WidthVariance = Random(start: 0f, end: 0f),
+                            ColorVariance = Random(start: 0f, end: 0f)
+                        }
+                    },
+                    Trail = new TrailDef
+                    {
+                        Enable = false,
+                        Textures = new[] {
+                            "AryxBallisticTracer",
+                        },
+                        TextureMode = Normal,
+                        DecayTime = 128,
+                        Color = Color(red: 15, green: 6, blue: 1, alpha: 1),
+                        Back = false,
+                        CustomWidth = 0,
+                        UseWidthVariance = false,
+                        UseColorFade = true,
+                    },
+                    OffsetEffect = new OffsetEffectDef
+                    {
+                        MaxOffset = 0,// 0 offset value disables this effect
+                        MinLength = 0.2f,
+                        MaxLength = 3,
+                    },
+                },
+            },
+            AmmoAudio = new AmmoAudioDef
+            {
+                TravelSound = "",
+                HitSound = "",
+                ShieldHitSound = "",
+                PlayerHitSound = "",
+                VoxelHitSound = "",
+                FloatingHitSound = "",
+                HitPlayChance = 0.5f,
+                HitPlayShield = true,
+            }, // Don't edit below this line
+            Ejection = new EjectionDef
+            {
+                Type = Particle, // Particle or Item (Inventory Component)
+                Speed = 100f, // Speed inventory is ejected from in dummy direction
+                SpawnChance = 0.5f, // chance of triggering effect (0 - 1)
+                CompDef = new ComponentDef
+                {
+                    ItemName = "", //InventoryComponent name
+                    ItemLifeTime = 0, // how long item should exist in world
+                    Delay = 0, // delay in ticks after shot before ejected
+                }
+            },
+        };
+
     }
 }

--- a/Data/Scripts/CoreParts/AryxGatlingVulcan_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxGatlingVulcan_Weapon.cs
@@ -25,7 +25,7 @@ namespace Scripts
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 0.2f,	 
+                        DurabilityMod = 0.1f,	 
 					},
                 },
                 Muzzles = new[] {
@@ -185,6 +185,7 @@ namespace Scripts
             },
             Ammos = new[] {
                 AryxVulcanAmmoWC,
+                AryxVulcanBusterAmmoWC,
             },
             Animations = AryxVulcanAnimations,
             // Don't edit below this line

--- a/Data/Scripts/CoreParts/AryxGatlingWarrior_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxGatlingWarrior_Weapon.cs
@@ -22,7 +22,7 @@ namespace Scripts {
                         MuzzlePartId = "MissileTurretBarrels", // The subpart where your muzzle empties are located.
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 0.15f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
+                        DurabilityMod = 0.075f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
                         IconName = "TestIcon.dds" // Overlay for block inventory slots, like reactors, refineries, etc.
                     },
                 },

--- a/Data/Scripts/CoreParts/AryxLaserModulus_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxLaserModulus_AmmoTypes.cs
@@ -29,7 +29,7 @@ namespace Scripts
         private AmmoDef AryxModulusLaser_VioletLaser => new AmmoDef //Longest range, lowest dmg.
         {
             AmmoMagazine = "Energy",
-            AmmoRound = "380nm Laser - MODVIO",
+            AmmoRound = "380nm Standard Laser",
             HybridRound = false, //AmmoMagazine based weapon with energy cost
             EnergyCost = 4f, //(((EnergyCost * DefaultDamage) * ShotsPerSecond) * BarrelsPerShot) * ShotsPerBarrel
             BaseDamage = (float)(450 * AWEGlobalDamageScalar),

--- a/Data/Scripts/CoreParts/AryxLaserModulus_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxLaserModulus_Weapon.cs
@@ -25,7 +25,7 @@ namespace Scripts
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 0.2f,
+                        DurabilityMod = 0.1f,
                     },
                 },
                 Muzzles = new[] {
@@ -118,8 +118,8 @@ namespace Scripts
                     ReloadTime = 1, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     DelayUntilFire = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     HeatPerShot = 10, //10 heat generated per shot
-                    MaxHeat = 6000, //max heat before weapon enters cooldown (70% of max heat)
-                    Cooldown = .75f, //percent of max heat to be under to start firing again after overheat accepts .2-.95
+                    MaxHeat = 2500, //max heat before weapon enters cooldown (70% of max heat)
+                    Cooldown = .25f, //percent of max heat to be under to start firing again after overheat accepts .2-.95
                     HeatSinkRate = 200, //amount of heat lost per second
                     DegradeRof = false, // progressively lower rate of fire after 80% heat threshold (80% of max heat)
                     ShotsInBurst = 0, //for beam this is time in ticks

--- a/Data/Scripts/CoreParts/AryxMissileBattery_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxMissileBattery_Weapon.cs
@@ -22,7 +22,7 @@ namespace Scripts {
                         MuzzlePartId = "MissileTurretBarrels", // The subpart where your muzzle empties are located.
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 3.0f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
+                        DurabilityMod = 1.0f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
                         IconName = "" // Overlay for block inventory slots, like reactors, refineries, etc.
                     },
                 },

--- a/Data/Scripts/CoreParts/AryxPDCAurora_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxPDCAurora_Weapon.cs
@@ -24,7 +24,7 @@ namespace Scripts {
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 0.06f,						
+                        DurabilityMod = 0.03f,						
                     },
 
                 },

--- a/Data/Scripts/CoreParts/AryxPDCGuardian_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxPDCGuardian_AmmoTypes.cs
@@ -100,7 +100,7 @@ namespace Scripts
                 {
                     Modifier = -1f,
                     Type = Default,
-                    BypassModifier = -2f,
+                    BypassModifier = -1f,
                 },
                 DamageType = new DamageTypes
                 {

--- a/Data/Scripts/CoreParts/AryxPDCGuardian_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxPDCGuardian_Weapon.cs
@@ -59,11 +59,11 @@ namespace Scripts
                 LockedSmartOnly = false, // Only fire at smart projectiles that are locked on to parent grid.
                 MinimumDiameter = 0, // 0 = unlimited, Minimum radius of threat to engage.
                 MaximumDiameter = 0, // 0 = unlimited, Maximum radius of threat to engage.
-                MaxTargetDistance = 0, // 0 = unlimited, Maximum target distance that targets will be automatically shot at.
+                MaxTargetDistance = 1600, // 0 = unlimited, Maximum target distance that targets will be automatically shot at.
                 MinTargetDistance = 0, // 0 = unlimited, Min target distance that targets will be automatically shot at.
-                TopTargets = 6, // 0 = unlimited, max number of top targets to randomize between.
+                TopTargets = 0, // 0 = unlimited, max number of top targets to randomize between.
                 TopBlocks = 0, // 0 = unlimited, max number of blocks to randomize between
-                StopTrackingSpeed = 0, // do not track target threats traveling faster than this speed
+                StopTrackingSpeed = 10000, // do not track target threats traveling faster than this speed
             },
             HardPoint = new HardPointDef
             {

--- a/Data/Scripts/CoreParts/AryxPDCGuardian_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxPDCGuardian_Weapon.cs
@@ -25,7 +25,7 @@ namespace Scripts
                         MuzzlePartId = "GatlingBarrel",
                         AzimuthPartId = "GatlingTurretBase1",
                         ElevationPartId = "GatlingTurretBase2",
-                        DurabilityMod = 0.2f,	 
+                        DurabilityMod = 0.1f,	 
 					},
                     new MountPointDef {
                         SubtypeId = "ARYXSlantedAtlasPDC",
@@ -33,7 +33,7 @@ namespace Scripts
                         MuzzlePartId = "GatlingBarrel",
                         AzimuthPartId = "GatlingTurretBase1",
                         ElevationPartId = "GatlingTurretBase2",
-                        DurabilityMod = 0.2f,
+                        DurabilityMod = 0.1f,
                     },
                 },
                 Muzzles = new[] {
@@ -59,11 +59,11 @@ namespace Scripts
                 LockedSmartOnly = false, // Only fire at smart projectiles that are locked on to parent grid.
                 MinimumDiameter = 0, // 0 = unlimited, Minimum radius of threat to engage.
                 MaximumDiameter = 0, // 0 = unlimited, Maximum radius of threat to engage.
-                MaxTargetDistance = 1600, // 0 = unlimited, Maximum target distance that targets will be automatically shot at.
+                MaxTargetDistance = 0, // 0 = unlimited, Maximum target distance that targets will be automatically shot at.
                 MinTargetDistance = 0, // 0 = unlimited, Min target distance that targets will be automatically shot at.
-                TopTargets = 0, // 0 = unlimited, max number of top targets to randomize between.
+                TopTargets = 6, // 0 = unlimited, max number of top targets to randomize between.
                 TopBlocks = 0, // 0 = unlimited, max number of blocks to randomize between
-                StopTrackingSpeed = 10000, // do not track target threats traveling faster than this speed
+                StopTrackingSpeed = 0, // do not track target threats traveling faster than this speed
             },
             HardPoint = new HardPointDef
             {

--- a/Data/Scripts/CoreParts/AryxPhaseMedusa_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxPhaseMedusa_AmmoTypes.cs
@@ -401,5 +401,381 @@ namespace Scripts
             }, // Don't edit below this line
         };
 
+
+        private AmmoDef AryxMedusaBusterAmmo => new AmmoDef
+        {
+            AmmoMagazine = "Energy", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo.
+            AmmoRound = "Medusa Bunker Buster Phase Bolt", // Name of ammo in terminal, should be different for each ammo type used by the same weapon.
+            HybridRound = false, // Use both a physical ammo magazine and energy per shot.
+            EnergyCost = 0.11851852f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
+            BaseDamage = (float)(1 * AWEGlobalDamageScalar), // Direct damage; one steel plate is worth 100.
+            Mass = 0, // In kilograms; how much force the impact will apply to the target.
+            Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.
+            BackKickForce = 0, // Recoil.
+            DecayPerShot = 0f, // Damage to the firing weapon itself.
+            HardPointUsable = true, // Whether this is a primary ammo type fired directly by the turret. Set to false if this is a shrapnel ammoType and you don't want the turret to be able to select it directly.
+            EnergyMagazineSize = 0, // For energy weapons, how many shots to fire before reloading.
+            IgnoreWater = false, // Whether the projectile should be able to penetrate water when using WaterMod.
+
+            Shape = new ShapeDef // Defines the collision shape of the projectile, defaults to LineShape and uses the visual Line Length if set to 0.
+            {
+                Shape = LineShape, // LineShape or SphereShape. Do not use SphereShape for fast moving projectiles if you care about precision.
+                Diameter = 1, // Diameter is minimum length of LineShape or minimum diameter of SphereShape.
+            },
+            ObjectsHit = new ObjectsHitDef
+            {
+                MaxObjectsHit = 0, // Limits the number of entities (grids, players, projectiles) the projectile can penetrate; 0 = unlimited.
+                CountBlocks = false, // Counts individual blocks, not just entities hit.
+            },
+            Fragment = new FragmentDef
+            {
+                AmmoRound = "",
+                Fragments = 0,
+                Degrees = 1,
+                Reverse = true,
+            },
+            Pattern = new PatternDef
+            {
+                Patterns = new[] { // If enabled, set of multiple ammos to fire in order instead of the main ammo.
+                    "",
+                },
+                Enable = false,
+                TriggerChance = 1f,
+                Random = false,
+                RandomMin = 1,
+                RandomMax = 1,
+                SkipParent = false,
+                PatternSteps = 1, // Number of Ammos activated per round, will progress in order and loop. Ignored if Random = true.
+            },
+            DamageScales = new DamageScaleDef
+            {
+                MaxIntegrity = 0f, // Blocks with integrity higher than this value will be immune to damage from this projectile; 0 = disabled.
+                DamageVoxels = false, // Whether to damage voxels.
+                SelfDamage = false, // Whether to damage the weapon's own grid.
+                HealthHitModifier = 1, // How much Health to subtract from another projectile on hit; defaults to 1 if zero or less.
+                VoxelHitModifier = 1, // Voxel damage multiplier; defaults to 1 if zero or less.
+                Characters = 1000f, // Character damage multiplier; defaults to 1 if zero or less.
+                // For the following modifier values: -1 = disabled (higher performance), 0 = no damage, 0.01f = 1% damage, 2 = 200% damage.
+                FallOff = new FallOffDef
+                {
+                    Distance = 5000, // Distance at which max damage begins falling off.
+                    MinMultipler = 1f, // value from 0.0f to 1f where 0.1f would be a min damage of 10% of max damage.
+                },
+                Grids = new GridSizeDef
+                {
+                    Large = 1f,
+                    Small = 1f,
+                },
+                Armor = new ArmorDef
+                {
+                    Armor = 0.0001f,
+                    Light = 1f,
+                    Heavy = 1f,
+                    NonArmor = 0.0001f,
+                },
+                Shields = new ShieldDef
+                {
+                    Modifier = 100f,
+                    Type = Default,
+                    BypassModifier = -1f,
+                },
+                DamageType = new DamageTypes
+                {
+                    Base = Energy,
+                    AreaEffect = Energy,
+                    Detonation = Energy,
+                    Shield = Energy,
+                },
+                Custom = new CustomScalesDef
+                {
+                    IgnoreAllOthers = false, // Pass through all blocks not listed below without damaging them.
+                    Types = new[] // List of blocks to apply custom damage multipliers to.
+                    {
+                        new CustomBlocksDef
+                        {
+                            SubTypeId = "Test1",
+                            Modifier = -1f,
+                        },
+                        new CustomBlocksDef
+                        {
+                            SubTypeId = "Test2",
+                            Modifier = -1f,
+                        },
+                    },
+                },
+            },
+			AreaOfDamage = new AreaOfDamageDef
+            {
+                ByBlockHit = new ByBlockHitDef
+                {
+                    Enable = false,
+                    Radius = 0f, // Meters
+                    Damage = 0,
+                    Depth = 1f, // Meters
+                    MaxAbsorb = 0f,
+                    Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius
+                    //.Linear drops evenly by distance from center out to max radius
+                    //.Curve drops off damage sharply as it approaches the max radius
+                    //.InvCurve drops off sharply from the middle and tapers to max radius
+                    //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
+                    //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
+                    Shape = Diamond, // Round or Diamond
+                },
+                EndOfLife = new EndOfLifeDef
+                {
+                    Enable = true,
+                    Radius = 3f, // Meters
+                    Damage = (float)(10000 * AWEGlobalDamageScalar),
+                    Depth = 1f,
+                    MaxAbsorb = 0f,
+                    Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius
+                    //.Linear drops evenly by distance from center out to max radius
+                    //.Curve drops off damage sharply as it approaches the max radius
+                    //.InvCurve drops off sharply from the middle and tapers to max radius
+                    //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
+                    //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
+                    ArmOnlyOnHit = false, // Detonation only is available, After it hits something, when this is true. IE, if shot down, it won't explode.
+                    MinArmingTime = 90, // In ticks, before the Ammo is allowed to explode, detonate or similar; This affects shrapnel spawning.
+                    NoVisuals = false,
+                    NoSound = false,
+                    ParticleScale = 1f,
+                    CustomParticle = "AryxAWE_Phase_Blast", // Particle SubtypeID, from your Particle SBC
+                    CustomSound = "ArcWepSmallMissileExplShip", // SubtypeID from your Audio SBC, not a filename
+                    Shape = Diamond, // Round or Diamond
+                }, 
+            },
+            Ewar = new EwarDef
+            {
+                Enable = false, // Enables EWAR effects AND DISABLES BASE DAMAGE AND AOE DAMAGE!!
+                Type = EnergySink, // EnergySink, Emp, Offense, Nav, Dot, AntiSmart, JumpNull, Anchor, Tractor, Pull, Push, 
+                Mode = Effect, // Effect , Field
+                Strength = 100f,
+                Radius = 5f, // Meters
+                Duration = 100, // In Ticks
+                StackDuration = true, // Combined Durations
+                Depletable = true,
+                MaxStacks = 10, // Max Debuffs at once
+                NoHitParticle = false,
+                /*
+                EnergySink : Targets & Shutdowns Power Supplies, such as Batteries & Reactor
+                Emp : Targets & Shutdown any Block capable of being powered
+                Offense : Targets & Shutdowns Weaponry
+                Nav : Targets & Shutdown Gyros, Thrusters, or Locks them down
+                Dot : Deals Damage to Blocks in radius
+                AntiSmart : Effects & Scrambles the Targeting List of Affected Missiles
+                JumpNull : Shutdown & Stops any Active Jumps, or JumpDrive Units in radius
+                Tractor : Affects target with Physics
+                Pull : Affects target with Physics
+                Push : Affects target with Physics
+                Anchor : Affects target with Physics
+                
+                */
+                Force = new PushPullDef
+                {
+                    ForceFrom = ProjectileLastPosition, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    ForceTo = HitPosition, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    Position = TargetCenterOfMass, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    DisableRelativeMass = false,
+                    TractorRange = 0,
+                    ShooterFeelsForce = false,
+                },
+                Field = new FieldDef
+                {
+                    Interval = 0, // Time between each pulse, in game ticks (60 == 1 second).
+                    PulseChance = 0, // Chance from 0 - 100 that an entity in the field will be hit by any given pulse.
+                    GrowTime = 0, // How many ticks it should take the field to grow to full size.
+                    HideModel = false, // Hide the projectile model if it has one.
+                    ShowParticle = true, // Show Block damage effect.
+                    TriggerRange = 250f, //range at which fields are triggered
+                    Particle = new ParticleDef // Particle effect to generate at the field's position.
+                    {
+                        Name = "", // SubtypeId of field particle effect.
+                        Extras = new ParticleOptionDef
+                        {
+                            Scale = 1, // Scale of effect.
+                        },
+                    },
+                },
+            },
+            Beams = new BeamDef
+            {
+                Enable = false, // Enable beam behaviour.
+                VirtualBeams = false, // Only one damaging beam, but with the effectiveness of the visual beams combined (better performance).
+                ConvergeBeams = false, // When using virtual beams, converge the visual beams to the location of the real beam.
+                RotateRealBeam = false, // The real beam is rotated between all visual beams, instead of centered between them.
+                OneParticle = false, // Only spawn one particle hit per beam weapon.
+            },
+            Trajectory = new TrajectoryDef
+            {
+                Guidance = None, // None, Remote, TravelTo, Smart, DetectTravelTo, DetectSmart, DetectFixed
+                TargetLossDegree = 80f,
+                TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                AccelPerSec = 0f,
+                DesiredSpeed = 800, // voxel phasing if you go above 5100
+                MaxTrajectory = 10000f,
+                //FieldTime was here, it's dead now is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
+                GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
+                SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed
+                RangeVariance = Random(start: 0, end: 0), // subtracts value from MaxTrajectory
+                MaxTrajectoryTime = 0, // How long the weapon must fire before it reaches MaxTrajectory.
+                Smarts = new SmartsDef
+                {
+                    Inaccuracy = 0f, // 0 is perfect, hit accuracy will be a random num of meters between 0 and this value.
+                    Aggressiveness = 1f, // controls how responsive tracking is.
+                    MaxLateralThrust = 0.5, // controls how sharp the trajectile may turn
+                    TrackingDelay = 0, // Measured in Shape diameter units traveled.
+                    MaxChaseTime = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    OverideTarget = true, // when set to true ammo picks its own target, does not use hardpoint's.
+                    MaxTargets = 0, // Number of targets allowed before ending, 0 = unlimited
+                    NoTargetExpire = false, // Expire without ever having a target at TargetLossTime
+                    Roam = false, // Roam current area after target loss
+                    KeepAliveAfterTargetLoss = false, // Whether to stop early death of projectile on target loss
+                    OffsetRatio = 0.05f, // The ratio to offset the random direction (0 to 1) 
+                    OffsetTime = 60, // how often to offset degree, measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..)
+                },
+                Mines = new MinesDef
+                {
+                    DetectRadius = 0,
+                    DeCloakRadius = 0,
+                    FieldTime = 0,
+                    Cloak = false,
+                    Persist = false,
+                },
+            },
+            AmmoGraphics = new GraphicDef
+            {
+                ModelName = "",
+                VisualProbability = 1f,
+                ShieldHitDraw = false,
+                Particles = new AmmoParticleDef
+                {
+                    Ammo = new ParticleDef
+                    {
+                        Name = "AryxAWE_PhaseBolt", //ShipWelderArc
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 128, green: 0, blue: 0, alpha: 32),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Restart = false,
+                            MaxDistance = 2500,
+                            MaxDuration = 0.1f,
+                            Scale = 2.5f,
+                        },
+                    },
+                    Hit = new ParticleDef
+                    {
+                        Name = "",
+                        ApplyToShield = true,
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 25, green: 10f, blue: 1, alpha: 1),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 30,
+                            Scale = 5,
+                            HitPlayChance = 1f,
+                        },
+                    },
+                    Eject = new ParticleDef
+                    {
+                        Name = "",
+                        ApplyToShield = true,
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 3, green: 1.9f, blue: 1f, alpha: 1),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 30,
+                            Scale = 1,
+                            HitPlayChance = 1f,
+                        },
+                    },
+                },
+                Lines = new LineDef
+                {
+                    ColorVariance = Random(start: 0.75f, end: 2f), // multiply the color by random values within range.
+                    WidthVariance = Random(start: 0f, end: 1.025f), // adds random value to default width (negatives shrinks width)
+                    Tracer = new TracerBaseDef
+                    {
+                        Enable = true,
+                        Length = 20f,
+                        Width = 1f,
+                        Color = Color(red: 11, green: 40, blue: 32, alpha: 1),
+                        VisualFadeStart = 0, // Number of ticks the weapon has been firing before projectiles begin to fade their color
+                        VisualFadeEnd = 0, // How many ticks after fade began before it will be invisible.
+                        Textures = new[] {// WeaponLaser, ProjectileTrailLine, WarpBubble, etc..
+                            "AryxBallisticTracer",
+                        },
+                        TextureMode = Normal, // Normal, Cycle, Chaos, Wave
+                        Segmentation = new SegmentDef
+                        {
+                            Enable = false, // If true Tracer TextureMode is ignored
+                            Textures = new[] {
+                                "",
+                            },
+                            SegmentLength = 0f, // Uses the values below.
+                            SegmentGap = 0f, // Uses Tracer textures and values
+                            Speed = 1f, // meters per second
+                            Color = Color(red: 1, green: 2, blue: 2.5f, alpha: 1),
+                            WidthMultiplier = 1f,
+                            Reverse = false,
+                            UseLineVariance = true,
+                            WidthVariance = Random(start: 0f, end: 0f),
+                            ColorVariance = Random(start: 0f, end: 0f)
+                        }
+                    },
+                    Trail = new TrailDef
+                    {
+                        Enable = true,
+                        Textures = new[] {
+                            "WeaponLaser",
+                        },
+                        TextureMode = Normal,
+                        DecayTime = 25,
+                        Color = Color(red: 5, green: 25, blue: 11, alpha: 1),
+                        Back = false,
+                        CustomWidth = 0.15f,
+                        UseWidthVariance = false,
+                        UseColorFade = true,
+                    },
+                    OffsetEffect = new OffsetEffectDef
+                    {
+                        MaxOffset = 0,// 0 offset value disables this effect
+                        MinLength = 0.2f,
+                        MaxLength = 3,
+                    },
+                },
+            },
+            AmmoAudio = new AmmoAudioDef
+            {
+                TravelSound = "",
+                HitSound = "",
+                ShieldHitSound = "",
+                PlayerHitSound = "",
+                VoxelHitSound = "",
+                FloatingHitSound = "",
+                HitPlayChance = 0.5f,
+                HitPlayShield = true,
+            },
+            Ejection = new EjectionDef
+            {
+                Type = Particle, // Particle or Item (Inventory Component)
+                Speed = 100f, // Speed inventory is ejected from in dummy direction
+                SpawnChance = 0.5f, // chance of triggering effect (0 - 1)
+                CompDef = new ComponentDef
+                {
+                    ItemName = "", //InventoryComponent name
+                    ItemLifeTime = 0, // how long item should exist in world
+                    Delay = 0, // delay in ticks after shot before ejected
+                }
+            }, // Don't edit below this line
+        };
+
     }
 }

--- a/Data/Scripts/CoreParts/AryxPhaseMedusa_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxPhaseMedusa_Weapon.cs
@@ -22,7 +22,7 @@ namespace Scripts {
                         MuzzlePartId = "MissileTurretBarrels", // The subpart where your muzzle empties are located.
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 0.25f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
+                        DurabilityMod = 0.083f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
                     },
                 },
                 Muzzles = new[] {
@@ -181,7 +181,8 @@ namespace Scripts {
                 },
             },
             Ammos = new[] {
-                AryxMedusaAmmo, // Must list all primary, shrapnel, and pattern ammos.
+                AryxMedusaAmmo,
+                AryxMedusaBusterAmmo, // Must list all primary, shrapnel, and pattern ammos.
             },
             //Animations = AryxWarriorAnimations,
             //Upgrades = UpgradeModules,

--- a/Data/Scripts/CoreParts/AryxPlasmaHelios_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxPlasmaHelios_AmmoTypes.cs
@@ -159,7 +159,7 @@ namespace Scripts
                     //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
                     //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
                     ArmOnlyOnHit = false, // Detonation only is available, After it hits something, when this is true. IE, if shot down, it won't explode.
-                    MinArmingTime = 90, // In ticks, before the Ammo is allowed to explode, detonate or similar; This affects shrapnel spawning.
+                    MinArmingTime = 180, // In ticks, before the Ammo is allowed to explode, detonate or similar; This affects shrapnel spawning.
                     NoVisuals = false,
                     NoSound = false,
                     ParticleScale = 1,
@@ -236,7 +236,7 @@ namespace Scripts
                 TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
-                DesiredSpeed = 2000,
+                DesiredSpeed = 1000,
                 MaxTrajectory = 10000,
                 //FieldTime was here, it's dead now is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.

--- a/Data/Scripts/CoreParts/AryxPlasmaHelios_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxPlasmaHelios_Weapon.cs
@@ -23,7 +23,7 @@ namespace Scripts
                         MuzzlePartId = "None",
                         AzimuthPartId = "None",
                         ElevationPartId = "None",
-                        DurabilityMod = 0.25f,
+                        DurabilityMod = 0.125f,
                     },
 
                 },
@@ -55,7 +55,7 @@ namespace Scripts
             HardPoint = new HardPointDef
             {
                 PartName = "Helios Plasma Cannon", // name of weapon in terminal
-                DeviateShotAngle = 0.15f,
+                DeviateShotAngle = 0.07f,
                 AimingTolerance = 1f, // 0 - 180 firing angle
                 AimLeadingPrediction = Off, // Off, Basic, Accurate, Advanced
                 DelayCeaseFire = 120, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
@@ -103,7 +103,7 @@ namespace Scripts
                     BarrelsPerShot = 1,
                     TrajectilesPerBarrel = 1, // Number of Trajectiles per barrel per fire event.
                     SkipBarrels = 0,
-                    ReloadTime = 600, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    ReloadTime = 820, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     DelayUntilFire = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     HeatPerShot = 0, //heat generated per shot
                     MaxHeat = 70000, //max heat before weapon enters cooldown (70% of max heat)

--- a/Data/Scripts/CoreParts/AryxPlasmaSpartan_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxPlasmaSpartan_AmmoTypes.cs
@@ -401,5 +401,379 @@ namespace Scripts
             },
         };
 
+        private AmmoDef AryxSpartanPlasmaBusterAmmo => new AmmoDef
+        {
+            AmmoMagazine = "Energy", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo
+            AmmoRound = "Spartan Bunker Buster Pulse", // name of ammo in terminal, should be unique for each ammo type. Used for Name field in server config
+            HybridRound = false, //AmmoMagazine based weapon with energy cost
+            EnergyCost = 0.102855967f, //(((EnergyCost * DefaultDamage) * ShotsPerSecond) * BarrelsPerShot) * ShotsPerBarrel
+            BaseDamage = (float)(1 * AWEGlobalDamageScalar),
+            Mass = 0, // in kilograms
+            Health = 0, // 0 = disabled, otherwise how much damage it can take from other trajectiles before dying.
+            BackKickForce = 0,
+            DecayPerShot = 0f,
+            HardPointUsable = true, // set to false if this is a shrapnel ammoType and you don't want the turret to be able to select it directly.
+            EnergyMagazineSize = 0,
+            IgnoreWater = false,
+
+            Shape = new ShapeDef //defines the collision shape of projectile, defaults line and visual Line Length if set to 0
+            {
+                Shape = LineShape, // LineShape or SphereShape. Do not use SphereShape for fast moving projectiles if you care about precision.
+                Diameter = 1, // Diameter is minimum length of LineShape or minimum diameter of SphereShape
+            },
+            ObjectsHit = new ObjectsHitDef
+            {
+                MaxObjectsHit = 0, // 0 = disabled
+                CountBlocks = false, // counts gridBlocks and not just entities hit
+            },
+            Fragment = new FragmentDef
+            {
+                AmmoRound = "",
+                Fragments = 100,
+                Degrees = 15,
+                Reverse = false,
+                
+            },
+            Pattern = new PatternDef
+            {
+                Patterns = new[] {
+                    "",
+                },
+                Enable = false,
+                TriggerChance = 1f,
+                Random = false,
+                RandomMin = 1,
+                RandomMax = 1,
+                SkipParent = false,
+                PatternSteps = 1, // Number of Ammos activated per round, will progress in order and loop.  Ignored if Random = true.
+            },
+            DamageScales = new DamageScaleDef
+            {
+                MaxIntegrity = 0f, // 0 = disabled, 1000 = any blocks with currently integrity above 1000 will be immune to damage.
+                DamageVoxels = false, // true = voxels are vulnerable to this weapon
+                SelfDamage = false, // true = allow self damage.
+                HealthHitModifier = 50, // defaults to a value of 1, this setting modifies how much Health is subtracted from a projectile per hit (1 = per hit).
+                VoxelHitModifier = 1,
+                Characters = 80f,
+                // modifier values: -1 = disabled (higher performance), 0 = no damage, 0.01 = 1% damage, 2 = 200% damage.
+                FallOff = new FallOffDef
+                {
+                    Distance = 1000f, // Distance at which max damage begins falling off.
+                    MinMultipler = 1f, // value from 0.0001f to 1f where 0.1f would be a min damage of 10% of max damage.
+                },
+                Grids = new GridSizeDef
+                {
+                    Large = -1f,
+                    Small = -1f,
+                },
+                Armor = new ArmorDef
+                {
+                    Armor = 0.0001f,
+                    Light = -1f,
+                    Heavy = -1f,
+                    NonArmor = 0.0001f,
+                },
+                Shields = new ShieldDef
+                {
+                    Modifier = 15f,
+                    Type = Default, // Default, Heal
+                    BypassModifier = -2f,
+                },
+                DamageType = new DamageTypes
+                {
+                    Base = Energy,
+                    AreaEffect = Energy,
+                    Detonation = Energy,
+                    Shield = Energy,
+                },
+                // first true/false (ignoreOthers) will cause projectiles to pass through all blocks that do not match the custom subtypeIds.
+                Custom = new CustomScalesDef
+                {
+                    IgnoreAllOthers = false,
+                    Types = new[]
+                    {
+                        new CustomBlocksDef
+                        {
+                            SubTypeId = "Test1",
+                            Modifier = -1f,
+                        },
+                        new CustomBlocksDef
+                        {
+                            SubTypeId = "Test2",
+                            Modifier = -1f,
+                        },
+                    },
+                },
+            },
+            AreaOfDamage = new AreaOfDamageDef
+            {
+                ByBlockHit = new ByBlockHitDef
+                {
+                    Enable = false,
+                    Radius = 0f, // Meters
+                    Damage = 0f,
+                    Depth = 1f, // Meters
+                    MaxAbsorb = 0f,
+                    Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius
+                    //.Linear drops evenly by distance from center out to max radius
+                    //.Curve drops off damage sharply as it approaches the max radius
+                    //.InvCurve drops off sharply from the middle and tapers to max radius
+                    //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
+                    //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
+                    Shape = Diamond, // Round or Diamond
+                },
+                EndOfLife = new EndOfLifeDef
+                {
+                    Enable = true,
+                    Radius = 1f, // Meters
+                    Damage = 2400f,
+                    Depth = 1f,
+                    MaxAbsorb = 0f,
+                    Falloff = Linear, //.NoFalloff applies the same damage to all blocks in radius
+                    //.Linear drops evenly by distance from center out to max radius
+                    //.Curve drops off damage sharply as it approaches the max radius
+                    //.InvCurve drops off sharply from the middle and tapers to max radius
+                    //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
+                    //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
+                    ArmOnlyOnHit = false, // Detonation only is available, After it hits something, when this is true. IE, if shot down, it won't explode.
+                    MinArmingTime = 90, // In ticks, before the Ammo is allowed to explode, detonate or similar; This affects shrapnel spawning.
+                    NoVisuals = false,
+                    NoSound = false,
+                    ParticleScale = 1,
+                    CustomParticle = "particleName", // Particle SubtypeID, from your Particle SBC
+                    CustomSound = "soundName", // SubtypeID from your Audio SBC, not a filename
+                    Shape = Round, // Round or Diamond
+                }, 
+            },
+            Ewar = new EwarDef
+            {
+                Enable = false, // Enables EWAR effects AND DISABLES BASE DAMAGE AND AOE DAMAGE!!
+                Type = EnergySink, // EnergySink, Emp, Offense, Nav, Dot, AntiSmart, JumpNull, Anchor, Tractor, Pull, Push, 
+                Mode = Effect, // Effect , Field
+                Strength = 100f,
+                Radius = 5f, // Meters
+                Duration = 100, // In Ticks
+                StackDuration = true, // Combined Durations
+                Depletable = true,
+                MaxStacks = 10, // Max Debuffs at once
+                NoHitParticle = false,
+                /*
+                EnergySink : Targets & Shutdowns Power Supplies, such as Batteries & Reactor
+                Emp : Targets & Shutdown any Block capable of being powered
+                Offense : Targets & Shutdowns Weaponry
+                Nav : Targets & Shutdown Gyros, Thrusters, or Locks them down
+                Dot : Deals Damage to Blocks in radius
+                AntiSmart : Effects & Scrambles the Targeting List of Affected Missiles
+                JumpNull : Shutdown & Stops any Active Jumps, or JumpDrive Units in radius
+                Tractor : Affects target with Physics
+                Pull : Affects target with Physics
+                Push : Affects target with Physics
+                Anchor : Affects target with Physics
+                
+                */
+                Force = new PushPullDef
+                {
+                    ForceFrom = ProjectileLastPosition, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    ForceTo = HitPosition, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    Position = TargetCenterOfMass, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    DisableRelativeMass = false,
+                    TractorRange = 0,
+                    ShooterFeelsForce = false,
+                },
+                Field = new FieldDef
+                {
+                    Interval = 0, // Time between each pulse, in game ticks (60 == 1 second).
+                    PulseChance = 0, // Chance from 0 - 100 that an entity in the field will be hit by any given pulse.
+                    GrowTime = 0, // How many ticks it should take the field to grow to full size.
+                    HideModel = false, // Hide the projectile model if it has one.
+                    ShowParticle = true, // Show Block damage effect.
+                    TriggerRange = 250f, //range at which fields are triggered
+                    Particle = new ParticleDef // Particle effect to generate at the field's position.
+                    {
+                        Name = "", // SubtypeId of field particle effect.
+                        Extras = new ParticleOptionDef
+                        {
+                            Scale = 1, // Scale of effect.
+                        },
+                    },
+                },
+            },
+            Beams = new BeamDef
+            {
+                Enable = false,
+                VirtualBeams = false, // Only one hot beam, but with the effectiveness of the virtual beams combined (better performace)
+                ConvergeBeams = false, // When using virtual beams this option visually converges the beams to the location of the real beam.
+                RotateRealBeam = false, // The real (hot beam) is rotated between all virtual beams, instead of centered between them.
+                OneParticle = false, // Only spawn one particle hit per beam weapon.
+            },
+            Trajectory = new TrajectoryDef
+            {
+                Guidance = None,
+                TargetLossDegree = 80f,
+                TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                AccelPerSec = 0f,
+                DesiredSpeed = 1000, // voxel phasing if you go above 5100
+                MaxTrajectory = 6000f,
+                //FieldTime was here, it's dead now is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
+                GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
+                SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed
+                RangeVariance = Random(start: 0, end: 0), // subtracts value from MaxTrajectory
+                MaxTrajectoryTime = 0, // How long the weapon must fire before it reaches MaxTrajectory.
+                Smarts = new SmartsDef
+                {
+                    Inaccuracy = 0f, // 0 is perfect, hit accuracy will be a random num of meters between 0 and this value.
+                    Aggressiveness = 1f, // controls how responsive tracking is.
+                    MaxLateralThrust = 0.5, // controls how sharp the trajectile may turn
+                    TrackingDelay = 0, // Measured in Shape diameter units traveled.
+                    MaxChaseTime = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    OverideTarget = true, // when set to true ammo picks its own target, does not use hardpoint's.
+                    MaxTargets = 0, // Number of targets allowed before ending, 0 = unlimited
+                    NoTargetExpire = false, // Expire without ever having a target at TargetLossTime
+                    Roam = false, // Roam current area after target loss
+                    KeepAliveAfterTargetLoss = false, // Whether to stop early death of projectile on target loss
+                },
+                Mines = new MinesDef
+                {
+                    DetectRadius = 0,
+                    DeCloakRadius = 0,
+                    FieldTime = 0,
+                    Cloak = false,
+                    Persist = false,
+                },
+            },
+            AmmoGraphics = new GraphicDef
+            {
+                ModelName = "",
+                VisualProbability = 1f,
+                ShieldHitDraw = false,
+                Particles = new AmmoParticleDef
+                {
+                    Ammo = new ParticleDef
+                    {
+                        Name = "", //ShipWelderArc
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 128, green: 0, blue: 0, alpha: 32),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 0,
+                            Scale = 1,
+                        },
+                    },
+                    Hit = new ParticleDef
+                    {
+                        Name = "",
+                        ApplyToShield = true,
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 25, green: 10f, blue: 1f, alpha: 1),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 0,
+                            Scale = 1,
+                            HitPlayChance = 1f,
+                        },
+                    },
+                    Eject = new ParticleDef
+                    {
+                        Name = "",
+                        ApplyToShield = true,
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 3, green: 1.9f, blue: 1f, alpha: 1),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 30,
+                            Scale = 1,
+                            HitPlayChance = 1f,
+                        },
+                    },
+                },
+                Lines = new LineDef
+                {
+                    ColorVariance = Random(start: -0.75f, end: 2f), // multiply the color by random values within range.
+                    WidthVariance = Random(start: 0f, end: 0.2f), // adds random value to default width (negatives shrinks width)
+                    Tracer = new TracerBaseDef
+                    {
+                        Enable = true,
+                        Length = 15f,
+                        Width = 1f,
+                        Color = Color(red: 3, green: 8, blue: 24, alpha: 1),
+                        VisualFadeStart = 0, // Number of ticks the weapon has been firing before projectiles begin to fade their color
+                        VisualFadeEnd = 0, // How many ticks after fade began before it will be invisible.
+                        Textures = new[] {// WeaponLaser, ProjectileTrailLine, WarpBubble, etc..
+                            "AryxBallisticTracer",
+                        },
+                        TextureMode = Normal, // Normal, Cycle, Chaos, Wave
+                        Segmentation = new SegmentDef
+                        {
+                            Enable = false, // If true Tracer TextureMode is ignored
+                            Textures = new[] {
+                                "AryxBallisticTracer",
+                            },
+                            SegmentLength = 0f, // Uses the values below.
+                            SegmentGap = 0f, // Uses Tracer textures and values
+                            Speed = 1f, // meters per second
+                            Color = Color(red: 1, green: 2, blue: 2.5f, alpha: 1),
+                            WidthMultiplier = 1f,
+                            Reverse = false,
+                            UseLineVariance = true,
+                            WidthVariance = Random(start: 0f, end: 0f),
+                            ColorVariance = Random(start: 0f, end: 0f)
+                        }
+                    },
+                    Trail = new TrailDef
+                    {
+                        Enable = false,
+                        Textures = new[] {
+                            "AryxBallisticTracer",
+                        },
+                        TextureMode = Normal,
+                        DecayTime = 128,
+                        Color = Color(red: 0, green: 0, blue: 1, alpha: 1),
+                        Back = false,
+                        CustomWidth = 0,
+                        UseWidthVariance = false,
+                        UseColorFade = true,
+                    },
+                    OffsetEffect = new OffsetEffectDef
+                    {
+                        MaxOffset = 0,// 0 offset value disables this effect
+                        MinLength = 0.2f,
+                        MaxLength = 3,
+                    },
+                },
+            },
+            AmmoAudio = new AmmoAudioDef
+            {
+                TravelSound = "",
+                HitSound = "",
+                ShieldHitSound = "",
+                PlayerHitSound = "",
+                VoxelHitSound = "",
+                FloatingHitSound = "",
+                HitPlayChance = 0.5f,
+                HitPlayShield = true,
+            }, // Don't edit below this line
+            Ejection = new EjectionDef
+            {
+                Type = Particle, // Particle or Item (Inventory Component)
+                Speed = 100f, // Speed inventory is ejected from in dummy direction
+                SpawnChance = 0.5f, // chance of triggering effect (0 - 1)
+                CompDef = new ComponentDef
+                {
+                    ItemName = "", //InventoryComponent name
+                    ItemLifeTime = 0, // how long item should exist in world
+                    Delay = 0, // delay in ticks after shot before ejected
+                }
+            },
+        };
       }
 }

--- a/Data/Scripts/CoreParts/AryxPlasmaSpartan_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxPlasmaSpartan_Weapon.cs
@@ -23,7 +23,7 @@ namespace Scripts {
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 0.2f,
+                        DurabilityMod = 0.1f,
                     },
                 },
                 Muzzles = new[] {
@@ -117,7 +117,7 @@ namespace Scripts {
                     BarrelsPerShot = 1,
                     TrajectilesPerBarrel = 1, // Number of Trajectiles per barrel per fire event.
                     SkipBarrels = 0,
-                    ReloadTime = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    ReloadTime = 1, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     DelayUntilFire = 0, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     HeatPerShot = 60, //heat generated per shot
                     MaxHeat = 10000, //max heat before weapon enters cooldown (70% of max heat)
@@ -179,6 +179,7 @@ namespace Scripts {
             },
             Ammos = new[] {
                 AryxSpartanPlasmaAmmo,
+                AryxSpartanPlasmaBusterAmmo,
             },
             //Animations = Weapon75_Animation,
             //Upgrades = UpgradeModules,

--- a/Data/Scripts/CoreParts/AryxPulseCannonReaper_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxPulseCannonReaper_AmmoTypes.cs
@@ -788,5 +788,393 @@ namespace Scripts
                 }
             },
         };
+
+        private AmmoDef AryxReaperBusterAmmoWC => new AmmoDef
+        {
+            AmmoMagazine = "AryxReaperPulseCell",
+            AmmoRound = "AryxReaperBusterAmmoWC",
+            HybridRound = false, //AmmoMagazine based weapon with energy cost
+            EnergyCost = 1f, //(((EnergyCost * DefaultDamage) * ShotsPerSecond) * BarrelsPerShot) * ShotsPerBarrel
+            BaseDamage = (float)(1 * AWEGlobalDamageScalar),
+            Mass = 0, // in kilograms
+            Health = 0, // 0 = disabled, otherwise how much damage it can take from other trajectiles before dying.
+            BackKickForce = 30f,
+            DecayPerShot = 0,
+            HardPointUsable = true, // set to false if this is a shrapnel ammoType and you don't want the turret to be able to select it directly.
+
+            Shape = new ShapeDef //defines the collision shape of projectile, defaults line and visual Line Length if set to 0
+            {
+                Shape = LineShape,
+                Diameter = 1,
+            },
+            ObjectsHit = new ObjectsHitDef
+            {
+                MaxObjectsHit = 0, // 0 = disabled
+                CountBlocks = false, // counts gridBlocks and not just entities hit
+            },
+            Fragment = new FragmentDef
+            {
+                AmmoRound = "Reaper Antimatter Bolt", // AmmoRound field of the ammo to spawn.
+                Fragments = 0, // Number of projectiles to spawn.
+                Degrees = 90, // Cone in which to randomize direction of spawned projectiles.
+                Reverse = false, // Spawn projectiles backward instead of forward.
+                DropVelocity = true, // fragments will not inherit velocity from parent.
+                Offset = 0f, // Offsets the fragment spawn by this amount, in meters (positive forward, negative for backwards).
+                Radial = 30f, // Determines starting angle for Degrees of spread above.  IE, 0 degrees and 90 radial goes perpendicular to travel path
+                IgnoreArming = true, //Whether shrapnel should spawn regardless of whether the projectile is armed or not.
+            },
+            Pattern = new PatternDef
+            {
+                Patterns = new[] {
+                    "",
+                },
+                Enable = false,
+                TriggerChance = 1f,
+                Random = false,
+                RandomMin = 1,
+                RandomMax = 1,
+                SkipParent = false,
+            },
+            DamageScales = new DamageScaleDef
+            {
+            MaxIntegrity = 0f, // Blocks with integrity higher than this value will be immune to damage from this projectile; 0 = disabled.
+            DamageVoxels = false, // Whether to damage voxels.
+            SelfDamage = false, // Whether to damage the weapon's own grid.
+            HealthHitModifier = 5000, // How much Health to subtract from another projectile on hit; defaults to 1 if zero or less.
+            VoxelHitModifier = 1, // Voxel damage multiplier; defaults to 1 if zero or less.
+            Characters = 350f, // Character damage multiplier; defaults to 1 if zero or less.
+                              // For the following modifier values: -1 = disabled (higher performance), 0 = no damage, 0.01f = 1% damage, 2 = 200% damage.
+            FallOff = new FallOffDef
+            {
+                Distance = 500f, // Distance at which damage begins falling off.
+                MinMultipler = 1f, // Value from 0.0001f to 1f where 0.1f would be a min damage of 10% of base damage.
+            },
+            Grids = new GridSizeDef
+            {
+                Large = -1f, // Multiplier for damage against large grids.
+                Small = -1f, // Multiplier for damage against small grids.
+            },
+            Armor = new ArmorDef
+            {
+                Armor = 0.0001f, // Multiplier for damage against all armor. This is multiplied with the specific armor type multiplier (light, heavy).
+                Light = -1f, // Multiplier for damage against light armor.
+                Heavy = -1f, // Multiplier for damage against heavy armor.
+                NonArmor = 0.0001f, // Multiplier for damage against every else.
+            },
+            Shields = new ShieldDef
+            {
+                Modifier = 30f, // Multiplier for damage against shields.
+                Type = Default, // Damage vs healing against shields; Default, Heal
+                BypassModifier = -2f, // If greater than zero, the percentage of damage that will penetrate the shield.
+            },
+            DamageType = new DamageTypes // Damage type of each element of the projectile's damage; Kinetic, Energy
+            {
+                Base = Energy,
+                AreaEffect = Energy,
+                Detonation = Energy,
+                Shield = Energy, // Damage against shields is currently all of one type per projectile.
+            },
+            Custom = new CustomScalesDef
+            {
+                IgnoreAllOthers = false, // Pass through all blocks not listed below without damaging them.
+                Types = new[] // List of blocks to apply custom damage multipliers to.
+                    {
+                        new CustomBlocksDef
+                        {
+                            SubTypeId = "Test1",
+                            Modifier = -1f,
+                        },
+                        new CustomBlocksDef
+                        {
+                            SubTypeId = "Test2",
+                            Modifier = -1f,
+                        },
+                    },
+            },
+        },
+
+			AreaOfDamage = new AreaOfDamageDef
+            {
+                ByBlockHit = new ByBlockHitDef
+                {
+                    Enable = false,
+                    Radius = 0f, // Meters
+                    Damage = 0,
+                    Depth = 1f, // Meters
+                    MaxAbsorb = 0f,
+                    Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius
+                    //.Linear drops evenly by distance from center out to max radius
+                    //.Curve drops off damage sharply as it approaches the max radius
+                    //.InvCurve drops off sharply from the middle and tapers to max radius
+                    //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
+                    //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
+                    Shape = Diamond, // Round or Diamond
+                },
+                EndOfLife = new EndOfLifeDef
+                {
+                    Enable = true,
+                    Radius = 4, // Meters
+                    Damage = 200000,
+                    Depth = 4f,
+                    MaxAbsorb = 0f,
+                    Falloff = Pooled, //.NoFalloff applies the same damage to all blocks in radius
+                    //.Linear drops evenly by distance from center out to max radius
+                    //.Curve drops off damage sharply as it approaches the max radius
+                    //.InvCurve drops off sharply from the middle and tapers to max radius
+                    //.Squeeze does little damage to the middle, but rapidly increases damage toward max radius
+                    //.Pooled damage behaves in a pooled manner that once exhausted damage ceases.
+                    ArmOnlyOnHit = false, // Detonation only is available, After it hits something, when this is true. IE, if shot down, it won't explode.
+                    MinArmingTime = 60, // In ticks, before the Ammo is allowed to explode, detonate or similar; This affects shrapnel spawning.
+                    NoVisuals = false,
+                    NoSound = false,
+                    ParticleScale = 1,
+                    CustomParticle = "AryxReaperBlast", // Particle SubtypeID, from your Particle SBC
+                    CustomSound = "", // SubtypeID from your Audio SBC, not a filename
+                    Shape = Diamond, // Round or Diamond
+                }, 
+            },
+            Ewar = new EwarDef
+            {
+                Enable = false, // Enables EWAR effects AND DISABLES BASE DAMAGE AND AOE DAMAGE!!
+                Type = EnergySink, // EnergySink, Emp, Offense, Nav, Dot, AntiSmart, JumpNull, Anchor, Tractor, Pull, Push, 
+                Mode = Effect, // Effect , Field
+                Strength = 100f,
+                Radius = 5f, // Meters
+                Duration = 100, // In Ticks
+                StackDuration = true, // Combined Durations
+                Depletable = true,
+                MaxStacks = 10, // Max Debuffs at once
+                NoHitParticle = false,
+                /*
+                EnergySink : Targets & Shutdowns Power Supplies, such as Batteries & Reactor
+                Emp : Targets & Shutdown any Block capable of being powered
+                Offense : Targets & Shutdowns Weaponry
+                Nav : Targets & Shutdown Gyros, Thrusters, or Locks them down
+                Dot : Deals Damage to Blocks in radius
+                AntiSmart : Effects & Scrambles the Targeting List of Affected Missiles
+                JumpNull : Shutdown & Stops any Active Jumps, or JumpDrive Units in radius
+                Tractor : Affects target with Physics
+                Pull : Affects target with Physics
+                Push : Affects target with Physics
+                Anchor : Affects target with Physics
+                
+                */
+                Force = new PushPullDef
+                {
+                    ForceFrom = ProjectileLastPosition, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    ForceTo = HitPosition, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    Position = TargetCenterOfMass, // ProjectileLastPosition, ProjectileOrigin, HitPosition, TargetCenter, TargetCenterOfMass
+                    DisableRelativeMass = false,
+                    TractorRange = 0,
+                    ShooterFeelsForce = false,
+                },
+                Field = new FieldDef
+                {
+                    Interval = 0, // Time between each pulse, in game ticks (60 == 1 second).
+                    PulseChance = 0, // Chance from 0 - 100 that an entity in the field will be hit by any given pulse.
+                    GrowTime = 0, // How many ticks it should take the field to grow to full size.
+                    HideModel = false, // Hide the projectile model if it has one.
+                    ShowParticle = true, // Show Block damage effect.
+                    TriggerRange = 250f, //range at which fields are triggered
+                    Particle = new ParticleDef // Particle effect to generate at the field's position.
+                    {
+                        Name = "", // SubtypeId of field particle effect.
+                        Extras = new ParticleOptionDef
+                        {
+                            Scale = 1, // Scale of effect.
+                        },
+                    },
+                },
+            },
+            Beams = new BeamDef
+            {
+                Enable = false,
+                VirtualBeams = false, // Only one hot beam, but with the effectiveness of the virtual beams combined (better performace)
+                ConvergeBeams = false, // When using virtual beams this option visually converges the beams to the location of the real beam.
+                RotateRealBeam = false, // The real (hot beam) is rotated between all virtual beams, instead of centered between them.
+                OneParticle = false, // Only spawn one particle hit per beam weapon.
+            },
+            Trajectory = new TrajectoryDef
+            {
+                Guidance = None,
+                TargetLossDegree = 80f,
+                TargetLossTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                AccelPerSec = 0f,
+                DesiredSpeed = 500,
+                MaxTrajectory = 1300,
+                //FieldTime was here, it's dead now is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
+                GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
+                SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed
+                RangeVariance = Random(start: 0, end: 0), // subtracts value from MaxTrajectory
+                MaxTrajectoryTime = 0, // How long the weapon must fire before it reaches MaxTrajectory.
+                Smarts = new SmartsDef
+                {
+                    Inaccuracy = 0f, // 0 is perfect, hit accuracy will be a random num of meters between 0 and this value.
+                    Aggressiveness = 1f, // controls how responsive tracking is.
+                    MaxLateralThrust = 0.5f, // controls how sharp the trajectile may turn
+                    TrackingDelay = 1, // Measured in Shape diameter units traveled.
+                    MaxChaseTime = 1800, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    OverideTarget = true, // when set to true ammo picks its own target, does not use hardpoint's.
+                    MaxTargets = 0, // Number of targets allowed before ending, 0 = unlimited
+                    NoTargetExpire = false, // Expire without ever having a target at TargetLossTime
+                    Roam = false, // Roam current area after target loss
+                },
+                Mines = new MinesDef
+                {
+                    DetectRadius = 200,
+                    DeCloakRadius = 100,
+                    FieldTime = 1800,
+                    Cloak = false,
+                    Persist = false,
+                },
+            },
+            AmmoGraphics = new GraphicDef
+            {
+                ModelName = "",
+                VisualProbability = 1f,
+                ShieldHitDraw = true,
+                Particles = new AmmoParticleDef
+                {
+                    Ammo = new ParticleDef
+                    {
+                        Name = "", //ShipWelderArc
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 1, green: 1, blue: 1, alpha: 1),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Loop = true,
+                            Restart = false,
+                            MaxDistance = 2500,
+                            MaxDuration = 0,
+                            Scale = 0.2f,
+                        },
+                    },
+                    Hit = new ParticleDef
+                    {
+                        Name = "",
+                        ApplyToShield = true,
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 25, green: 10f, blue: 1f, alpha: 1),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Loop = false,
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 30,
+                            Scale = 5,
+                            HitPlayChance = 1f,
+                        },
+                    },
+                    Eject = new ParticleDef
+                    {
+                        Name = "",
+                        ApplyToShield = true,
+                        //shrinkbydistance = false, obselete
+                        Color = Color(red: 3, green: 1.9f, blue: 1f, alpha: 1),
+                        Offset = Vector(x: 0, y: 0, z: 0),
+                        Extras = new ParticleOptionDef
+                        {
+                            Loop = false,
+                            Restart = false,
+                            MaxDistance = 5000,
+                            MaxDuration = 30,
+                            Scale = 1,
+                            HitPlayChance = 1f,
+                        },
+                    },
+                },
+                Lines = new LineDef
+                {
+                    ColorVariance = Random(start: 0.75f, end: 2f), // multiply the color by random values within range.
+                    WidthVariance = Random(start: 0f, end: 1.025f), // adds random value to default width (negatives shrinks width)
+                    Tracer = new TracerBaseDef
+                    {
+                        Enable = true,
+                        Length = 50f,
+                        Width = 10f,
+                        Color = Color(red: 25, green: 15, blue: 15, alpha: 1),
+                        VisualFadeStart = 0, // Number of ticks the weapon has been firing before projectiles begin to fade their color
+                        VisualFadeEnd = 0, // How many ticks after fade began before it will be invisible.
+                        Textures = new[] {// WeaponLaser, ProjectileTrailLine, WarpBubble, etc..
+                            "AryxReaperBolt1",
+                            "AryxReaperBolt2",
+                            "AryxReaperBolt3",
+                            "AryxReaperBolt4",
+                            "AryxReaperBolt5",
+                        },
+                        TextureMode = Chaos, // Normal, Cycle, Chaos, Wave
+                        Segmentation = new SegmentDef
+                        {
+                            Enable = false, // If true Tracer TextureMode is ignored
+                            Textures = new[] {
+                                "BlackFireSeg1",
+                                "BlackFireSeg2",
+                                "BlackFireSeg3",
+                                "BlackFireSeg4",
+                                "BlackFireSeg5",
+                                "BlackFireSeg6",
+                                "BlackFireSeg7",
+                                "BlackFireSeg8",
+                            },
+                            SegmentLength = 30f, // Uses the values below.
+                            SegmentGap = 0f, // Uses Tracer textures and values
+                            Speed = 800f, // meters per second
+                            Color = Color(red: 2.5f, green: 2, blue: 1f, alpha: 1),
+                            WidthMultiplier = 1f,
+                            Reverse = false,
+                            UseLineVariance = true,
+                            WidthVariance = Random(start: 0f, end: 0.25f),
+                            ColorVariance = Random(start: 0f, end: 0f)
+                        }
+                    },
+                    Trail = new TrailDef
+                    {
+                        Enable = true,
+                        Textures = new[] {
+                            "WeaponLaser",
+                        },
+                        TextureMode = Normal,
+                        DecayTime = 64,
+                        Color = Color(red: 20, green: 9, blue: 9, alpha: 1),
+                        Back = false,
+                        CustomWidth = 0.2f,
+                        UseWidthVariance = false,
+                        UseColorFade = true,
+                    },
+                    OffsetEffect = new OffsetEffectDef
+                    {
+                        MaxOffset = 0,// 0 offset value disables this effect
+                        MinLength = 0.2f,
+                        MaxLength = 3,
+                    },
+                },
+            },
+            AmmoAudio = new AmmoAudioDef
+            {
+                TravelSound = "",
+                HitSound = "",
+                ShieldHitSound = "",
+                PlayerHitSound = "",
+                VoxelHitSound = "",
+                FloatingHitSound = "",
+                HitPlayChance = 0.5f,
+                HitPlayShield = true,
+            }, // Don't edit below this line
+            Ejection = new EjectionDef
+            {
+                Type = Particle, // Particle or Item (Inventory Component)
+                Speed = 100f, // Speed inventory is ejected from in dummy direction
+                SpawnChance = 0.5f, // chance of triggering effect (0 - 1)
+                CompDef = new ComponentDef
+                {
+                    ItemName = "", //InventoryComponent name
+                    ItemLifeTime = 0, // how long item should exist in world
+                    Delay = 0, // delay in ticks after shot before ejected
+                }
+            },
+        };
     }
 }

--- a/Data/Scripts/CoreParts/AryxPulseCannonReaper_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxPulseCannonReaper_Weapon.cs
@@ -24,7 +24,7 @@ namespace Scripts
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 0.2f,
+                        DurabilityMod = 0.067f,
                     },
 
                 },
@@ -166,6 +166,7 @@ namespace Scripts
             },
             Ammos = new[] {
                 AryxReaperAmmoWC,
+                AryxReaperBusterAmmoWC,
                 AryxReaperAntimatterAmmo,
             },
             //Animations = AryxReaperAnims,

--- a/Data/Scripts/CoreParts/AryxRailgunAntaeus_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxRailgunAntaeus_Weapon.cs
@@ -118,7 +118,7 @@ namespace Scripts {
                     BarrelsPerShot = 1, // How many muzzles will fire a projectile per fire event.
                     TrajectilesPerBarrel = 1, // Number of projectiles per muzzle per fire event.
                     SkipBarrels = 0, // Number of muzzles to skip after each fire event.
-                    ReloadTime = 300, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
+                    ReloadTime = 120, // Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     MagsToLoad = 1, // Number of physical magazines to consume on reload.
                     DelayUntilFire = 0, // How long the weapon waits before shooting after being told to fire. Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                     HeatPerShot = 0, // Heat generated per shot.

--- a/Data/Scripts/CoreParts/AryxRailgunApollo_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxRailgunApollo_Weapon.cs
@@ -22,7 +22,7 @@ namespace Scripts {
                         MuzzlePartId = "MissileTurretBarrels", // The subpart where your muzzle empties are located.
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 0.25f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
+                        DurabilityMod = 0.125f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
                         IconName = "TestIcon.dds" // Overlay for block inventory slots, like reactors, refineries, etc.
                     },
                 },

--- a/Data/Scripts/CoreParts/AryxRailgunAres_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxRailgunAres_Weapon.cs
@@ -24,7 +24,7 @@ namespace Scripts
                         MuzzlePartId = "None",
                         AzimuthPartId = "None",
                         ElevationPartId = "None",
-                        DurabilityMod = 3.0f,
+                        DurabilityMod = 1.5f,
                     },
 
                 },

--- a/Data/Scripts/CoreParts/AryxRailgunAriadne_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxRailgunAriadne_Weapon.cs
@@ -24,7 +24,7 @@ namespace Scripts
                         MuzzlePartId = "MissileTurretBarrels",
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 2.0f
+                        DurabilityMod = 0.667f
                     },
 
                 },

--- a/Data/Scripts/CoreParts/AryxRailgunAthena_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxRailgunAthena_Weapon.cs
@@ -22,7 +22,7 @@ namespace Scripts {
                         MuzzlePartId = "MissileTurretBarrels", // The subpart where your muzzle empties are located.
                         AzimuthPartId = "MissileTurretBase1",
                         ElevationPartId = "MissileTurretBarrels",
-                        DurabilityMod = 0.25f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
+                        DurabilityMod = 0.125f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
                     },
                 },
                 Muzzles = new[] {

--- a/Data/Scripts/CoreParts/AryxRailgunLight_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxRailgunLight_AmmoTypes.cs
@@ -31,7 +31,7 @@ namespace Scripts
             AmmoMagazine = "AryxSmallRailgunMagDef", // SubtypeId of physical ammo magazine. Use "Energy" for weapons without physical ammo.
             AmmoRound = "AryxPDRailgunAmmo", // Name of ammo in terminal, should be different for each ammo type used by the same weapon.
             HybridRound = true, // Use both a physical ammo magazine and energy per shot.
-            EnergyCost = 0.05f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
+            EnergyCost = 0.02f, // Scaler for energy per shot (EnergyCost * BaseDamage * (RateOfFire / 3600) * BarrelsPerShot * TrajectilesPerBarrel). Uses EffectStrength instead of BaseDamage if EWAR.
             BaseDamage = (float)(15500 * AWEGlobalDamageScalar), // Direct damage; one steel plate is worth 100.
             Mass = 10f, // In kilograms; how much force the impact will apply to the target.
             Health = 0, // How much damage the projectile can take from other projectiles (base of 1 per hit) before dying; 0 disables this and makes the projectile untargetable.

--- a/Data/Scripts/CoreParts/AryxShotgunMace_AmmoTypes.cs
+++ b/Data/Scripts/CoreParts/AryxShotgunMace_AmmoTypes.cs
@@ -83,8 +83,8 @@ namespace Scripts
                 // For the following modifier values: -1 = disabled (higher performance), 0 = no damage, 0.01f = 1% damage, 2 = 200% damage.
                 FallOff = new FallOffDef
                 {
-                    Distance = 10f, // Distance at which damage begins falling off.
-                    MinMultipler = 0.25f, // Value from 0.0001f to 1f where 0.1f would be a min damage of 10% of base damage.
+                    Distance = 300f, // Distance at which damage begins falling off.
+                    MinMultipler = 0.5f, // Value from 0.0001f to 1f where 0.1f would be a min damage of 10% of base damage.
                 },
                 Grids = new GridSizeDef
                 {

--- a/Data/Scripts/CoreParts/AryxShotgunMace_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxShotgunMace_Weapon.cs
@@ -22,7 +22,7 @@ namespace Scripts {
                         MuzzlePartId = "None", // The subpart where your muzzle empties are located.
                         AzimuthPartId = "None",
                         ElevationPartId = "None",
-                        DurabilityMod = 0.25f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
+                        DurabilityMod = 0.125f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
                         IconName = "TestIcon.dds" // Overlay for block inventory slots, like reactors, refineries, etc.
                     },
                 },

--- a/Data/Scripts/CoreParts/AryxSiegeMortar_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxSiegeMortar_Weapon.cs
@@ -25,7 +25,7 @@ namespace Scripts
                         MuzzlePartId = "MortarElevation",
                         AzimuthPartId = "MortarAzimuth",
                         ElevationPartId = "MortarElevation",
-                        DurabilityMod = 0.25f
+                        DurabilityMod = 0.125f
                     },
                 },
                 Muzzles = new[] {
@@ -116,7 +116,7 @@ namespace Scripts
                     BarrelsPerShot = 1,
                     TrajectilesPerBarrel = 1, // Number of Trajectiles per barrel per fire event.
                     SkipBarrels = 0,
-                    ReloadTime = 240, // 29 second reload time on the avalanche.
+                    ReloadTime = 360, // 29 second reload time on the avalanche.
                     DelayUntilFire = 15, 
                     HeatPerShot = 0, //heat generated per shot
                     MaxHeat = 70000, //max heat before weapon enters cooldown (70% of max heat)

--- a/Data/Scripts/CoreParts/AryxSuperlaserAtlas_Weapon.cs
+++ b/Data/Scripts/CoreParts/AryxSuperlaserAtlas_Weapon.cs
@@ -22,7 +22,7 @@ namespace Scripts {
                         MuzzlePartId = "None", // The subpart where your muzzle empties are located.
                         AzimuthPartId = "None",
                         ElevationPartId = "None",
-                        DurabilityMod = 0.4f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
+                        DurabilityMod = 0.2f, // GeneralDamageMultiplier, 0.25f = 25% damage taken.
                         IconName = "TestIcon.dds" // Overlay for block inventory slots, like reactors, refineries, etc.
                     },
                 },


### PR DESCRIPTION
- Increased the resistance of all guns by 2-3 times
- Added "Bunker Buster" alternate ammo types to the 3 shock cannons, medusa, reaper, spartan, echo, punisher, and vulcan.
 	- These ammo types do crushing shield damage but travel slowly and have a minarming time to prevent face hugging with them.
	- Intended as an easier counter to stationary fortified grids (you'll likely still need an inhibitor to maximize their effectiveness).
- Decreased PCU cost of mortar and helios to 2000 and 750 respectively. ROF slightly nerfed as well but their DPS / PCU is up overall.
	- Intended to encourage players to carry a few "just in case" as an additional way to make countering fortified grids easier.
- Decreased helios muzzle velocity to 1km/s, and increased minarming time to 3 seconds (3km minimum distance). Decreased deviation to hit better at long ranges.
- Increased mace shotgun's falloff start to 300 and made the falloff curve half as steep.
- Decreased the modulus's maximum heat so it doesn't have such a long initial burst when starting combat.
- Updated weapon descriptions and added cold dps bonuses when applicable.
- Gave SG antaeus's ROF some love since the last railgun update unintentionally nerfed it into the ground.
