### PR TITLE
Update JumpDriveInhibitorBlock.cs

### DIFF
--- a/Data/Scripts/JumpDriveInhibitor/JumpDriveInhibitorBlock.cs
+++ b/Data/Scripts/JumpDriveInhibitor/JumpDriveInhibitorBlock.cs
@@ -15,7 +15,7 @@ namespace GrunkQuest
     public class InhibRewrite : MyGameLogicComponent
     {
         public const double INHIB_ACTIVE_TIME = 45.0;
-        public const double INHIB_COOLDOWN_TIME = 135.0;
+        public const double INHIB_COOLDOWN_TIME = 85.0;
 
         public InhibitorState InhibState;
 


### PR DESCRIPTION
Rebuffing slightly. Timing with two inhibitors leaves just 40s open, which, when used 10s apart to interrupt jumps in progress, leaves just 20s of "safe time" unless three inhibitors are used. By that point the ship has lost a lot of available PCU and gained so much mass that it's a dedicated tackler instead of a dedicated max range kiter. This tactic required four before, which was a little too restrictive to the balancing purpose. Uptime remains the same, so as to maintain good windows of opportunity (11km may be traversed in the timeframe, or 4.5km in the difference between fastest and slowest ships).